### PR TITLE
Remove references to invalid CAs

### DIFF
--- a/python/psycopg/README.md
+++ b/python/psycopg/README.md
@@ -48,8 +48,7 @@ The code automatically detects the user type and adjusts its behavior accordingl
 
 ### Download the Amazon root certificate from the official trust store
 
-Download the Amazon root certificate from the official trust store. This example shows one of the available certs that
-can be used by the client. Other certs such as AmazonRootCA2.pem, AmazonRootCA3.pem, etc. can also be used.
+Download the Amazon root certificate from the official trust store:
 
 ```
 wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem

--- a/python/psycopg2/README.md
+++ b/python/psycopg2/README.md
@@ -48,8 +48,7 @@ The code automatically detects the user type and adjusts its behavior accordingl
 
 ### Download the Amazon root certificate from the official trust store
 
-Download the Amazon root certificate from the official trust store. This example shows one of the available certs that
-can be used by the client. Other certs such as AmazonRootCA2.pem, AmazonRootCA3.pem, etc. can also be used.
+Download the Amazon root certificate from the official trust store:
 
 ```
 wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem

--- a/python/sqlalchemy/README.md
+++ b/python/sqlalchemy/README.md
@@ -52,8 +52,7 @@ The code automatically detects the user type and adjusts its behavior accordingl
 
 ### Download the Amazon root certificate from the official trust store
 
-Download the Amazon root certificate from the official trust store. This example shows one of the available certs that
-can be used by the client. Other certs such as AmazonRootCA2.pem, AmazonRootCA3.pem, etc. can also be used.
+Download the Amazon root certificate from the official trust store:
 
 ```
 wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem

--- a/ruby/rails/petclinic/README.md
+++ b/ruby/rails/petclinic/README.md
@@ -44,9 +44,7 @@ Install the Rails application:
 ```sh
 cd petclinic
 
-# Download the Amazon root certificate from the official trust store
-# This example shows one of the available certs that can be used by the client;
-# other certs such as AmazonRootCA2.pem, AmazonRootCA3.pem, etc. can also be used.
+# Download the Amazon root certificate from the official trust store:
 wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem
 
 bundle install

--- a/ruby/ruby-pg/README.md
+++ b/ruby/ruby-pg/README.md
@@ -96,9 +96,7 @@ bundle install
 
 ### Download the Amazon root certificate from the official trust store
 
-Download the Amazon root certificate from the official trust store.
-This example shows one of the available certs that can be used by the client.
-Other certs such as AmazonRootCA2.pem, AmazonRootCA3.pem, etc. can also be used.
+Download the Amazon root certificate from the official trust store:
 
 ```
 wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem


### PR DESCRIPTION
Fix documentation and remove references to other certificates than `AmazonRootCA1.pem`.

By submitting this pull request, I confirm that my contribution is made under 
the terms of the MIT-0 license.