### PR TITLE
java: Add multi-Region examples for cluster management

### DIFF
--- a/java/cluster_management/pom.xml
+++ b/java/cluster_management/pom.xml
@@ -12,7 +12,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>org.example.Example</mainClass>
-        <project.build.awssdk.version>2.31.41</project.build.awssdk.version>
+        <project.build.awssdk.version>2.31.43</project.build.awssdk.version>
     </properties>
 
     <dependencies>

--- a/java/cluster_management/src/main/java/org/example/CreateMultiRegionClusters.java
+++ b/java/cluster_management/src/main/java/org/example/CreateMultiRegionClusters.java
@@ -1,0 +1,97 @@
+package org.example;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.services.dsql.DsqlClient;
+import software.amazon.awssdk.services.dsql.DsqlClientBuilder;
+import software.amazon.awssdk.services.dsql.model.CreateClusterRequest;
+import software.amazon.awssdk.services.dsql.model.CreateClusterResponse;
+import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
+import software.amazon.awssdk.services.dsql.model.UpdateClusterRequest;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+public class CreateMultiRegionClusters {
+
+    public static void main(String[] args) {
+        Region region1 = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
+        Region region2 = Region.of(System.getenv().getOrDefault("REGION_2", "us-east-2"));
+        Region witnessRegion = Region.of(System.getenv().getOrDefault("WITNESS_REGION", "us-west-2"));
+
+        DsqlClientBuilder clientBuilder = DsqlClient.builder()
+                .credentialsProvider(DefaultCredentialsProvider.create());
+
+        try (
+            DsqlClient client1 = clientBuilder.region(region1).build();
+            DsqlClient client2 = clientBuilder.region(region2).build()
+        ) {
+            List<GetClusterResponse> clusters = example(client1, client2, witnessRegion);
+            System.out.println("Created clusters:");
+            clusters.forEach(System.out::println);
+        }
+    }
+
+    public static List<GetClusterResponse> example(DsqlClient client1, DsqlClient client2, Region witnessRegion) {
+        // We can only set the witness region on the first cluster.
+        System.out.println("Creating cluster in " + client1.serviceClientConfiguration().region());
+        CreateClusterRequest request1 = CreateClusterRequest.builder()
+                .deletionProtectionEnabled(true)
+                .multiRegionProperties(mrp -> mrp.witnessRegion(witnessRegion.toString()))
+                .tags(Map.of(
+                        "Name", "java multi region cluster",
+                        "Repo", "aws-samples/aurora-dsql-samples"
+                ))
+                .build();
+        CreateClusterResponse cluster1 = client1.createCluster(request1);
+        System.out.println("Created " + cluster1.arn());
+
+        // For the second cluster we can set the witness region and designate
+        // cluster1 as a peer.
+        System.out.println("Creating cluster in " + client2.serviceClientConfiguration().region());
+        CreateClusterRequest request2 = CreateClusterRequest.builder()
+                .deletionProtectionEnabled(true)
+                .multiRegionProperties(mrp ->
+                        mrp.witnessRegion(witnessRegion.toString()).clusters(cluster1.arn())
+                )
+                .tags(Map.of(
+                        "Name", "java multi region cluster",
+                        "Repo", "aws-samples/aurora-dsql-samples"
+                ))
+                .build();
+        CreateClusterResponse cluster2 = client2.createCluster(request2);
+        System.out.println("Created " + cluster2.arn());
+
+        // Now that we know the cluster2 ARN we can set it as a peer of cluster1.
+        UpdateClusterRequest updateReq = UpdateClusterRequest.builder()
+                .identifier(cluster1.identifier())
+                .multiRegionProperties(mrp ->
+                        mrp.witnessRegion(witnessRegion.toString()).clusters(cluster2.arn())
+                )
+                .build();
+        client1.updateCluster(updateReq);
+        System.out.printf("Added %s as a peer of %s%n", cluster2.arn(), cluster1.arn());
+
+        // MultiRegionProperties is fully defined so both clusters will begin the
+        // transition to ACTIVE.
+        System.out.printf("Waiting for cluster %s to become ACTIVE%n", cluster1.arn());
+        GetClusterResponse activeCluster1 = client1.waiter().waitUntilClusterActive(
+                getCluster -> getCluster.identifier(cluster1.identifier()),
+                config -> config.backoffStrategyV2(
+                        BackoffStrategy.fixedDelayWithoutJitter(Duration.ofSeconds(10))
+                ).waitTimeout(Duration.ofMinutes(5))
+        ).matched().response().orElseThrow();
+
+        System.out.printf("Waiting for cluster %s to become ACTIVE%n", cluster2.arn());
+        GetClusterResponse activeCluster2 = client2.waiter().waitUntilClusterActive(
+                getCluster -> getCluster.identifier(cluster2.identifier()),
+                config -> config.backoffStrategyV2(
+                        BackoffStrategy.fixedDelayWithoutJitter(Duration.ofSeconds(10))
+                ).waitTimeout(Duration.ofMinutes(5))
+        ).matched().response().orElseThrow();
+
+        return List.of(activeCluster1, activeCluster2);
+    }
+}

--- a/java/cluster_management/src/main/java/org/example/DeleteMultiRegionClusters.java
+++ b/java/cluster_management/src/main/java/org/example/DeleteMultiRegionClusters.java
@@ -1,0 +1,64 @@
+package org.example;
+
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.api.BackoffStrategy;
+import software.amazon.awssdk.services.dsql.DsqlClient;
+import software.amazon.awssdk.services.dsql.DsqlClientBuilder;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public class DeleteMultiRegionClusters {
+
+    public static void main(String[] args) {
+        Region region1 = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
+        String clusterId1 = Optional.ofNullable(System.getenv("CLUSTER_ID_1"))
+                .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID_1 in environment"));
+        Region region2 = Region.of(System.getenv().getOrDefault("REGION_2", "us-east-1"));
+        String clusterId2 = Optional.ofNullable(System.getenv("CLUSTER_ID_2"))
+                .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID_2 in environment"));
+
+        DsqlClientBuilder clientBuilder = DsqlClient.builder()
+                .credentialsProvider(DefaultCredentialsProvider.create());
+
+        try (
+            DsqlClient client1 = clientBuilder.region(region1).build();
+            DsqlClient client2 = clientBuilder.region(region2).build()
+        ) {
+            example(client1, clusterId1, client2, clusterId2);
+        }
+    }
+
+    public static void example(DsqlClient client1, String clusterId1, DsqlClient client2, String clusterId2) {
+        System.out.printf("Deleting cluster %s in %s%n", clusterId1, client1.serviceClientConfiguration().region());
+        client1.deleteCluster(r -> r.identifier(clusterId1));
+
+        // cluster1 will stay in PENDING_DELETE until cluster2 is deleted.
+
+        System.out.printf("Deleting cluster %s in %s%n", clusterId2, client2.serviceClientConfiguration().region());
+        client2.deleteCluster(r -> r.identifier(clusterId2));
+
+        // Now that both clusters have been marked for deletion they will transition
+        // to DELETING state and finalize deletion.
+        System.out.printf("Waiting for cluster %s to finish deletion%n", clusterId1);
+        client1.waiter().waitUntilClusterNotExists(
+                getCluster -> getCluster.identifier(clusterId1),
+                config -> config.backoffStrategyV2(
+                        BackoffStrategy.fixedDelayWithoutJitter(Duration.ofSeconds(10))
+                ).waitTimeout(Duration.ofMinutes(5))
+        );
+
+        System.out.printf("Waiting for cluster %s to finish deletion%n", clusterId2);
+        client2.waiter().waitUntilClusterNotExists(
+                getCluster -> getCluster.identifier(clusterId2),
+                config -> config.backoffStrategyV2(
+                        BackoffStrategy.fixedDelayWithoutJitter(Duration.ofSeconds(10))
+                ).waitTimeout(Duration.ofMinutes(5))
+        );
+
+        System.out.printf("Deleted %s in %s and %s in %s%n",
+                clusterId1, client1.serviceClientConfiguration().region(),
+                clusterId2, client2.serviceClientConfiguration().region());
+    }
+}


### PR DESCRIPTION
What it says on the tin. I also removed the `ListTagsForResource` call in the sweeper because the latest SDK has `Tags` on the `GetClusterResponse` (hooray!)

---

By submitting this pull request, I confirm that my contribution is made under 
the terms of the MIT-0 license.

Thank you for your contribution!