### PR TITLE
Align all env variables for cluster management in all languages

### DIFF
--- a/.github/workflows/cpp-cm-integ-tests.yml
+++ b/.github/workflows/cpp-cm-integ-tests.yml
@@ -78,6 +78,9 @@ jobs:
         WITNESS_REGION: us-west-2
       run: |
         ./example
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -90,3 +93,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/dotnet-cm-integ-tests.yml
+++ b/.github/workflows/dotnet-cm-integ-tests.yml
@@ -48,6 +48,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
     steps:
       - name: Checkout code
@@ -80,3 +83,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/go-cm-integ-tests.yml
+++ b/.github/workflows/go-cm-integ-tests.yml
@@ -90,6 +90,9 @@ jobs:
       run: |
         go env -w GOPROXY=direct
         go test
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -102,3 +105,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/java-cm-integ-tests.yml
+++ b/.github/workflows/java-cm-integ-tests.yml
@@ -57,6 +57,9 @@ jobs:
         mvn initialize
         mvn clean compile assembly:single
         mvn test
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -69,3 +72,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/javascript-cm-integ-tests.yml
+++ b/.github/workflows/javascript-cm-integ-tests.yml
@@ -52,6 +52,9 @@ jobs:
         run: |
           npm install
           npm test
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -64,3 +67,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/python-cm-integ-tests.yml
+++ b/.github/workflows/python-cm-integ-tests.yml
@@ -65,6 +65,9 @@ jobs:
         pip list
         echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
         pytest -v test/
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -77,3 +80,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/ruby-cm-integ-tests.yml
+++ b/.github/workflows/ruby-cm-integ-tests.yml
@@ -51,6 +51,9 @@ jobs:
       run: |
         bundle install
         rspec
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -63,3 +66,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/rust-cm-integ-tests.yml
+++ b/.github/workflows/rust-cm-integ-tests.yml
@@ -65,6 +65,9 @@ jobs:
         working-directory: ./rust/cluster_management
         run: |
           cargo test -- --nocapture
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -77,3 +80,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/cpp/cluster_management/src/Example.cpp
+++ b/cpp/cluster_management/src/Example.cpp
@@ -46,7 +46,7 @@ int TestSingleRegion() {
     const int wait_for_cluster_seconds = 240; // Just an approximate arbitrarily chosen time
     
     Aws::String region = "us-east-1";
-    if (const char* env_var = std::getenv("CLUSTER_1_REGION")) {
+    if (const char* env_var = std::getenv("CLUSTER_REGION")) {
         region = env_var;
     } 
 

--- a/go/cluster_management/cmd/create_multi_region/create_multi_region.go
+++ b/go/cluster_management/cmd/create_multi_region/create_multi_region.go
@@ -146,8 +146,8 @@ func main() {
 
 	witnessRegion := util.GetEnvWithDefault("WITNESS_REGION", "us-west-2")
 
-	region1 := util.GetEnvWithDefault("REGION_1", "us-east-1")
-	region2 := util.GetEnvWithDefault("REGION_2", "us-east-2")
+	region1 := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
+	region2 := util.GetEnvWithDefault("CLUSTER_2_REGION", "us-east-2")
 
 	err := CreateMultiRegionClusters(ctx, witnessRegion, region1, region2)
 	if err != nil {

--- a/go/cluster_management/cmd/create_single_region/create_single_region.go
+++ b/go/cluster_management/cmd/create_single_region/create_single_region.go
@@ -68,7 +68,7 @@ func CreateCluster(ctx context.Context, region string) error {
 // Example usage in main function
 func main() {
 
-	region := util.GetEnvWithDefault("REGION_1", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
 
 	// Set up context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)

--- a/go/cluster_management/cmd/create_single_region/create_single_region.go
+++ b/go/cluster_management/cmd/create_single_region/create_single_region.go
@@ -68,7 +68,7 @@ func CreateCluster(ctx context.Context, region string) error {
 // Example usage in main function
 func main() {
 
-	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_REGION", "us-east-1")
 
 	// Set up context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)

--- a/go/cluster_management/cmd/delete_multi_region/delete_multi_region.go
+++ b/go/cluster_management/cmd/delete_multi_region/delete_multi_region.go
@@ -88,10 +88,10 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	region1 := util.GetEnvWithDefault("REGION_1", "us-east-1")
-	region2 := util.GetEnvWithDefault("REGION_2", "us-east-2")
-	clusterId1 := util.GetEnvWithDefault("CLUSTER_ID_1", "CLUSTER_ID_1")
-	clusterId2 := util.GetEnvWithDefault("CLUSTER_ID_2", "CLUSTER_ID_2")
+	region1 := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
+	region2 := util.GetEnvWithDefault("CLUSTER_2_REGION", "us-east-2")
+	clusterId1 := util.GetEnvWithDefault("CLUSTER_1_ID", "CLUSTER_1_ID")
+	clusterId2 := util.GetEnvWithDefault("CLUSTER_2_ID", "CLUSTER_2_ID")
 
 	err := DeleteMultiRegionClusters(
 		ctx,

--- a/go/cluster_management/cmd/delete_multi_region/delete_multi_region_cluster_integ_test.go
+++ b/go/cluster_management/cmd/delete_multi_region/delete_multi_region_cluster_integ_test.go
@@ -45,9 +45,9 @@ func setup() {
 		return
 	}
 
-	os.Setenv("REGION", "us-east-1")
+	os.Setenv("CLUSTER_1_REGION", "us-east-1")
 	os.Setenv("CLUSTER_1_ID", *output.Identifier)
-	os.Setenv("REGION2", "us-east-2")
+	os.Setenv("CLUSTER_2_REGION", "us-east-2")
 	os.Setenv("CLUSTER_2_ID", *output1.Identifier)
 }
 

--- a/go/cluster_management/cmd/delete_multi_region/delete_multi_region_cluster_integ_test.go
+++ b/go/cluster_management/cmd/delete_multi_region/delete_multi_region_cluster_integ_test.go
@@ -46,9 +46,9 @@ func setup() {
 	}
 
 	os.Setenv("REGION", "us-east-1")
-	os.Setenv("CLUSTER1_ID", *output.Identifier)
+	os.Setenv("CLUSTER_1_ID", *output.Identifier)
 	os.Setenv("REGION2", "us-east-2")
-	os.Setenv("CLUSTER2_ID", *output1.Identifier)
+	os.Setenv("CLUSTER_2_ID", *output1.Identifier)
 }
 
 func teardown() {
@@ -69,9 +69,9 @@ func TestDeleteMultiRegionClustersRegion(t *testing.T) {
 		{
 			name:        "Delete multi-region cluster",
 			region1:     "us-east-1",
-			identifier1: os.Getenv("CLUSTER1_ID"),
+			identifier1: os.Getenv("CLUSTER_1_ID"),
 			region2:     "us-east-2",
-			identifier2: os.Getenv("CLUSTER2_ID"),
+			identifier2: os.Getenv("CLUSTER_2_ID"),
 			wantErr:     false,
 		},
 	}

--- a/go/cluster_management/cmd/delete_single_region/delete_single_region.go
+++ b/go/cluster_management/cmd/delete_single_region/delete_single_region.go
@@ -70,7 +70,7 @@ func main() {
 		log.Fatal("CLUSTER_ID environment variable is not set")
 	}
 
-	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_REGION", "us-east-1")
 
 	err := DeleteSingleRegion(ctx, identifier, region)
 	if err != nil {

--- a/go/cluster_management/cmd/delete_single_region/delete_single_region.go
+++ b/go/cluster_management/cmd/delete_single_region/delete_single_region.go
@@ -70,7 +70,7 @@ func main() {
 		log.Fatal("CLUSTER_ID environment variable is not set")
 	}
 
-	region := util.GetEnvWithDefault("REGION_1", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
 
 	err := DeleteSingleRegion(ctx, identifier, region)
 	if err != nil {

--- a/go/cluster_management/cmd/get_cluster/get_cluster_integ.go
+++ b/go/cluster_management/cmd/get_cluster/get_cluster_integ.go
@@ -46,7 +46,7 @@ func main() {
 		log.Fatal("CLUSTER_ID environment variable is not set")
 	}
 
-	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_REGION", "us-east-1")
 
 	_, err := GetCluster(ctx, region, identifier)
 	if err != nil {

--- a/go/cluster_management/cmd/get_cluster/get_cluster_integ.go
+++ b/go/cluster_management/cmd/get_cluster/get_cluster_integ.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"example/internal/util"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"log"
 	"os"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 
 	"github.com/aws/aws-sdk-go-v2/service/dsql"
 )
@@ -45,7 +46,7 @@ func main() {
 		log.Fatal("CLUSTER_ID environment variable is not set")
 	}
 
-	region := util.GetEnvWithDefault("REGION_1", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
 
 	_, err := GetCluster(ctx, region, identifier)
 	if err != nil {

--- a/go/cluster_management/cmd/get_cluster/get_cluster_integ_test.go
+++ b/go/cluster_management/cmd/get_cluster/get_cluster_integ_test.go
@@ -34,7 +34,7 @@ func setup() {
 	}
 
 	// Set up any environment variables needed for tests
-	os.Setenv("REGION", "us-east-1")
+	os.Setenv("CLUSTER_REGION", "us-east-1")
 	os.Setenv("CLUSTER_ID", *output.Identifier)
 }
 
@@ -53,7 +53,7 @@ func TestGetCluster(t *testing.T) {
 	}{
 		{
 			name:       "Get cluster retrieval",
-			region:     os.Getenv("REGION"),
+			region:     os.Getenv("CLUSTER_REGION"),
 			identifier: os.Getenv("CLUSTER_ID"),
 			wantErr:    false,
 		},

--- a/go/cluster_management/cmd/update_cluster/update_cluster.go
+++ b/go/cluster_management/cmd/update_cluster/update_cluster.go
@@ -3,10 +3,11 @@ package main
 import (
 	"context"
 	"example/internal/util"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"log"
 	"os"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
 
 	"github.com/aws/aws-sdk-go-v2/service/dsql"
 )
@@ -47,7 +48,7 @@ func main() {
 		log.Fatal("CLUSTER_ID environment variable is not set")
 	}
 
-	region := util.GetEnvWithDefault("REGION_1", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
 
 	_, err := UpdateCluster(ctx, identifier, region, deleteProtection)
 	if err != nil {

--- a/go/cluster_management/cmd/update_cluster/update_cluster.go
+++ b/go/cluster_management/cmd/update_cluster/update_cluster.go
@@ -48,7 +48,7 @@ func main() {
 		log.Fatal("CLUSTER_ID environment variable is not set")
 	}
 
-	region := util.GetEnvWithDefault("CLUSTER_1_REGION", "us-east-1")
+	region := util.GetEnvWithDefault("CLUSTER_REGION", "us-east-1")
 
 	_, err := UpdateCluster(ctx, identifier, region, deleteProtection)
 	if err != nil {

--- a/go/cluster_management/cmd/update_cluster/update_cluster_integ_test.go
+++ b/go/cluster_management/cmd/update_cluster/update_cluster_integ_test.go
@@ -27,7 +27,7 @@ func setup() {
 	// Initialize context with timeout for all tests
 	testCtx, cancel = context.WithTimeout(context.Background(), 10*time.Minute)
 
-	output, err := util.FindClusterWithTagAndRepository(testCtx, util.GetEnvWithDefault("REGION", "us-east-1"),
+	output, err := util.FindClusterWithTagAndRepository(testCtx, util.GetEnvWithDefault("CLUSTER_REGION", "us-east-1"),
 		"Name", util.GetUniqueRunTagName("go single region cluster"))
 
 	if err != nil || output == nil || output.Identifier == nil {
@@ -35,7 +35,7 @@ func setup() {
 		return
 	}
 	// Set up any environment variables needed for test
-	if err := os.Setenv("REGION", util.GetEnvWithDefault("REGION", "us-east-1")); err != nil {
+	if err := os.Setenv("CLUSTER_REGION", util.GetEnvWithDefault("CLUSTER_REGION", "us-east-1")); err != nil {
 		fmt.Errorf("Error setting REGION environment variable")
 		return
 	}
@@ -60,7 +60,7 @@ func TestUpdateCluster(t *testing.T) {
 	}{
 		{
 			name:       "Update cluster to disable delete protection",
-			region:     os.Getenv("REGION"),
+			region:     os.Getenv("CLUSTER_REGION"),
 			identifier: os.Getenv("CLUSTER_ID"),
 			wantErr:    false,
 		},

--- a/java/cluster_management/README.md
+++ b/java/cluster_management/README.md
@@ -30,12 +30,13 @@ in [`DsqlClusterManagementTest.java`](src/test/java/org/example/DsqlClusterManag
 Optionally configure the regions for cluster creation and run with `mvn test`:
 
 ```sh
-# Optional: Single-Region examples will execute in CLUSTER_1_REGION. Defaults to 'us-east-1'.
-export CLUSTER_1_REGION="us-east-1"
+# Optional: Single-Region examples will execute in CLUSTER_REGION. Defaults to 'us-east-1'.
+export CLUSTER_REGION="us-east-1"
 
 # Optional: Multi-Region examples will create clusters in CLUSTER_1_REGION and CLUSTER_2_REGION
 # with WITNESS_REGION as witness for both. Defaults to 'us-east-2' for CLUSTER_2_REGION
 # and 'us-west-2' for WITNESS_REGION.
+export CLUSTER_1_REGION="us-east-1"
 export CLUSTER_2_REGION="us-east-2"
 export WITNESS_REGION="us-west-2"
 
@@ -56,7 +57,7 @@ The build process will produce a single `.jar` that can be invoked as:
 mvn clean compile assembly:single
 
 # Check each operation for its expected environment variables
-CLUSTER_1_REGION="us-east-1" CLUSTER_ID="<your cluster id>" \
+CLUSTER_REGION="us-east-1" CLUSTER_ID="<your cluster id>" \
   java \
   -cp target/AuroraDSQLClusterCrudExample-1.0-SNAPSHOT-jar-with-dependencies.jar \
   org.example.GetCluster

--- a/java/cluster_management/README.md
+++ b/java/cluster_management/README.md
@@ -13,11 +13,11 @@ in [`DsqlClusterManagementTest.java`](src/test/java/org/example/DsqlClusterManag
 
 ### ⚠️ Important
 
-* Running this code might result in charges to your AWS account.
-* We recommend that you grant your code least privilege. At most, grant only the
+- Running this code might result in charges to your AWS account.
+- We recommend that you grant your code least privilege. At most, grant only the
   minimum permissions required to perform the task. For more information, see
   [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
-* This code is not tested in every AWS Region. For more information, see
+- This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
 ### Prerequisites
@@ -30,13 +30,13 @@ in [`DsqlClusterManagementTest.java`](src/test/java/org/example/DsqlClusterManag
 Optionally configure the regions for cluster creation and run with `mvn test`:
 
 ```sh
-# Optional: Single-Region examples will execute in REGION_1. Defaults to 'us-east-1'.
-export REGION_1="us-east-1"
+# Optional: Single-Region examples will execute in CLUSTER_1_REGION. Defaults to 'us-east-1'.
+export CLUSTER_1_REGION="us-east-1"
 
-# Optional: Multi-Region examples will create clusters in REGION_1 and REGION_2
-# with WITNESS_REGION as witness for both. Defaults to 'us-east-2' for REGION_2
+# Optional: Multi-Region examples will create clusters in CLUSTER_1_REGION and CLUSTER_2_REGION
+# with WITNESS_REGION as witness for both. Defaults to 'us-east-2' for CLUSTER_2_REGION
 # and 'us-west-2' for WITNESS_REGION.
-export REGION_2="us-east-2"
+export CLUSTER_2_REGION="us-east-2"
 export WITNESS_REGION="us-west-2"
 
 # Will create, update, read, then delete clusters
@@ -46,15 +46,17 @@ mvn test
 Test execution will take around five minutes as it waits for clusters to complete activation and deletion.
 
 ### Executing single operations
+
 Files in [src/../example/](src/main/java/org/example) each have a `main()` method that let you exercise single operations.
 
 The build process will produce a single `.jar` that can be invoked as:
+
 ```shell
 # Build the project if this has not been done yet with 'mvn test'
 mvn clean compile assembly:single
 
 # Check each operation for its expected environment variables
-REGION_1="us-east-1" CLUSTER_ID="<your cluster id>" \
+CLUSTER_1_REGION="us-east-1" CLUSTER_ID="<your cluster id>" \
   java \
   -cp target/AuroraDSQLClusterCrudExample-1.0-SNAPSHOT-jar-with-dependencies.jar \
   org.example.GetCluster
@@ -65,4 +67,3 @@ REGION_1="us-east-1" CLUSTER_ID="<your cluster id>" \
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 SPDX-License-Identifier: MIT-0
-

--- a/java/cluster_management/src/main/java/org/example/CreateCluster.java
+++ b/java/cluster_management/src/main/java/org/example/CreateCluster.java
@@ -1,5 +1,8 @@
 package org.example;
 
+import java.time.Duration;
+import java.util.Map;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
@@ -8,13 +11,10 @@ import software.amazon.awssdk.services.dsql.model.CreateClusterRequest;
 import software.amazon.awssdk.services.dsql.model.CreateClusterResponse;
 import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
 
-import java.time.Duration;
-import java.util.Map;
-
 public class CreateCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
 
         try (
                 DsqlClient client = DsqlClient.builder()

--- a/java/cluster_management/src/main/java/org/example/CreateCluster.java
+++ b/java/cluster_management/src/main/java/org/example/CreateCluster.java
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
 public class CreateCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_REGION", "us-east-1"));
 
         try (
                 DsqlClient client = DsqlClient.builder()

--- a/java/cluster_management/src/main/java/org/example/CreateMultiRegionClusters.java
+++ b/java/cluster_management/src/main/java/org/example/CreateMultiRegionClusters.java
@@ -1,5 +1,9 @@
 package org.example;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
@@ -10,15 +14,11 @@ import software.amazon.awssdk.services.dsql.model.CreateClusterResponse;
 import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
 import software.amazon.awssdk.services.dsql.model.UpdateClusterRequest;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-
 public class CreateMultiRegionClusters {
 
     public static void main(String[] args) {
-        Region region1 = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
-        Region region2 = Region.of(System.getenv().getOrDefault("REGION_2", "us-east-2"));
+        Region region1 = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
+        Region region2 = Region.of(System.getenv().getOrDefault("CLUSTER_2_REGION", "us-east-2"));
         Region witnessRegion = Region.of(System.getenv().getOrDefault("WITNESS_REGION", "us-west-2"));
 
         DsqlClientBuilder clientBuilder = DsqlClient.builder()

--- a/java/cluster_management/src/main/java/org/example/DeleteCluster.java
+++ b/java/cluster_management/src/main/java/org/example/DeleteCluster.java
@@ -1,18 +1,18 @@
 package org.example;
 
+import java.time.Duration;
+import java.util.Optional;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.dsql.DsqlClient;
 import software.amazon.awssdk.services.dsql.model.DeleteClusterResponse;
 
-import java.time.Duration;
-import java.util.Optional;
-
 public class DeleteCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
         String clusterId = Optional.ofNullable(System.getenv("CLUSTER_ID"))
                 .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID in environment"));
 

--- a/java/cluster_management/src/main/java/org/example/DeleteCluster.java
+++ b/java/cluster_management/src/main/java/org/example/DeleteCluster.java
@@ -12,7 +12,7 @@ import software.amazon.awssdk.services.dsql.model.DeleteClusterResponse;
 public class DeleteCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_REGION", "us-east-1"));
         String clusterId = Optional.ofNullable(System.getenv("CLUSTER_ID"))
                 .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID in environment"));
 

--- a/java/cluster_management/src/main/java/org/example/DeleteMultiRegionClusters.java
+++ b/java/cluster_management/src/main/java/org/example/DeleteMultiRegionClusters.java
@@ -1,23 +1,23 @@
 package org.example;
 
+import java.time.Duration;
+import java.util.Optional;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.BackoffStrategy;
 import software.amazon.awssdk.services.dsql.DsqlClient;
 import software.amazon.awssdk.services.dsql.DsqlClientBuilder;
 
-import java.time.Duration;
-import java.util.Optional;
-
 public class DeleteMultiRegionClusters {
 
     public static void main(String[] args) {
-        Region region1 = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
-        String clusterId1 = Optional.ofNullable(System.getenv("CLUSTER_ID_1"))
-                .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID_1 in environment"));
-        Region region2 = Region.of(System.getenv().getOrDefault("REGION_2", "us-east-1"));
-        String clusterId2 = Optional.ofNullable(System.getenv("CLUSTER_ID_2"))
-                .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID_2 in environment"));
+        Region region1 = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
+        String clusterId1 = Optional.ofNullable(System.getenv("CLUSTER_1_ID"))
+                .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_1_ID in environment"));
+        Region region2 = Region.of(System.getenv().getOrDefault("CLUSTER_2_REGION", "us-east-1"));
+        String clusterId2 = Optional.ofNullable(System.getenv("CLUSTER_2_ID"))
+                .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_2_ID in environment"));
 
         DsqlClientBuilder clientBuilder = DsqlClient.builder()
                 .credentialsProvider(DefaultCredentialsProvider.create());

--- a/java/cluster_management/src/main/java/org/example/GetCluster.java
+++ b/java/cluster_management/src/main/java/org/example/GetCluster.java
@@ -1,16 +1,16 @@
 package org.example;
 
+import java.util.Optional;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dsql.DsqlClient;
 import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
 
-import java.util.Optional;
-
 public class GetCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
         String clusterId = Optional.ofNullable(System.getenv("CLUSTER_ID"))
                 .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID in environment"));
 

--- a/java/cluster_management/src/main/java/org/example/GetCluster.java
+++ b/java/cluster_management/src/main/java/org/example/GetCluster.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
 public class GetCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_REGION", "us-east-1"));
         String clusterId = Optional.ofNullable(System.getenv("CLUSTER_ID"))
                 .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID in environment"));
 

--- a/java/cluster_management/src/main/java/org/example/UpdateCluster.java
+++ b/java/cluster_management/src/main/java/org/example/UpdateCluster.java
@@ -1,16 +1,16 @@
 package org.example;
 
+import java.util.Optional;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dsql.DsqlClient;
 import software.amazon.awssdk.services.dsql.model.UpdateClusterResponse;
 
-import java.util.Optional;
-
 public class UpdateCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("REGION_1", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
         String clusterId = Optional.ofNullable(System.getenv("CLUSTER_ID"))
                 .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID in environment"));
 

--- a/java/cluster_management/src/main/java/org/example/UpdateCluster.java
+++ b/java/cluster_management/src/main/java/org/example/UpdateCluster.java
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.dsql.model.UpdateClusterResponse;
 public class UpdateCluster {
 
     public static void main(String[] args) {
-        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_1_REGION", "us-east-1"));
+        Region region = Region.of(System.getenv().getOrDefault("CLUSTER_REGION", "us-east-1"));
         String clusterId = Optional.ofNullable(System.getenv("CLUSTER_ID"))
                 .orElseThrow(() -> new IllegalStateException("Expected CLUSTER_ID in environment"));
 

--- a/java/cluster_management/src/test/java/org/example/DsqlClusterManagementTest.java
+++ b/java/cluster_management/src/test/java/org/example/DsqlClusterManagementTest.java
@@ -20,6 +20,11 @@ public class DsqlClusterManagementTest {
 
     private static final Logger logger = Logger.getLogger(DsqlClusterManagementTest.class.getSimpleName());
 
+    // Single Region Cluster
+    private static Region region;
+    private static DsqlClient client;
+
+    // Multi Region Clusters
     private static Region region1;
     private static Region region2;
     private static Region witnessRegion;
@@ -30,6 +35,8 @@ public class DsqlClusterManagementTest {
     @BeforeAll
     static void setup() {
         Map<String, String> env = System.getenv();
+        
+        region = Region.of(env.getOrDefault("CLUSTER_REGION", "us-east-1"));
         region1 = Region.of(env.getOrDefault("CLUSTER_1_REGION", "us-east-1"));
         region2 = Region.of(env.getOrDefault("CLUSTER_2_REGION", "us-east-2"));
         witnessRegion = Region.of(env.getOrDefault("WITNESS_REGION", "us-west-2"));
@@ -39,6 +46,7 @@ public class DsqlClusterManagementTest {
                 region1, region2, witnessRegion
                 ));
 
+        client = createClient(region);
         client1 = createClient(region1);
         client2 = createClient(region2);
     }
@@ -52,17 +60,17 @@ public class DsqlClusterManagementTest {
     @Test
     public void singleRegionClusterLifecycle() {
         logger.info("Starting single region cluster lifecycle run");
-        GetClusterResponse cluster = CreateCluster.example(client1);
+        GetClusterResponse cluster = CreateCluster.example(client);
         logger.info("Created " + cluster);
 
         logger.info("Disabling deletion protection");
-        UpdateCluster.example(client1, cluster.identifier(), false);
+        UpdateCluster.example(client, cluster.identifier(), false);
 
-        GetClusterResponse updatedCluster = GetCluster.example(client1, cluster.identifier());
+        GetClusterResponse updatedCluster = GetCluster.example(client, cluster.identifier());
         logger.info("Cluster after update: " + updatedCluster);
 
         logger.info("Deleting " + cluster.arn());
-        DeleteCluster.example(client1, cluster.identifier());
+        DeleteCluster.example(client, cluster.identifier());
         logger.info("Finished single region cluster lifecycle run");
     }
 

--- a/java/cluster_management/src/test/java/org/example/DsqlClusterManagementTest.java
+++ b/java/cluster_management/src/test/java/org/example/DsqlClusterManagementTest.java
@@ -1,17 +1,20 @@
 package org.example;
 
-import org.junit.jupiter.api.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dsql.DsqlClient;
 import software.amazon.awssdk.services.dsql.model.ClusterStatus;
 import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
 import software.amazon.awssdk.utils.builder.SdkBuilder;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Logger;
 
 public class DsqlClusterManagementTest {
 
@@ -27,12 +30,12 @@ public class DsqlClusterManagementTest {
     @BeforeAll
     static void setup() {
         Map<String, String> env = System.getenv();
-        region1 = Region.of(env.getOrDefault("REGION_1", "us-east-1"));
-        region2 = Region.of(env.getOrDefault("REGION_2", "us-east-2"));
+        region1 = Region.of(env.getOrDefault("CLUSTER_1_REGION", "us-east-1"));
+        region2 = Region.of(env.getOrDefault("CLUSTER_2_REGION", "us-east-2"));
         witnessRegion = Region.of(env.getOrDefault("WITNESS_REGION", "us-west-2"));
 
         logger.info(String.format(
-                "Executing tests with REGION_1=%s REGION_2=%s WITNESS_REGION=%s",
+                "Executing tests with CLUSTER_1_REGION=%s CLUSTER_2_REGION=%s WITNESS_REGION=%s",
                 region1, region2, witnessRegion
                 ));
 

--- a/java/cluster_management/src/test/java/org/example/DsqlClusterManagementTest.java
+++ b/java/cluster_management/src/test/java/org/example/DsqlClusterManagementTest.java
@@ -2,7 +2,6 @@ package org.example;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.logging.Logger;
 
 import org.junit.jupiter.api.AfterAll;
@@ -12,9 +11,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dsql.DsqlClient;
-import software.amazon.awssdk.services.dsql.model.ClusterStatus;
 import software.amazon.awssdk.services.dsql.model.GetClusterResponse;
-import software.amazon.awssdk.utils.builder.SdkBuilder;
 
 public class DsqlClusterManagementTest {
 
@@ -53,6 +50,7 @@ public class DsqlClusterManagementTest {
 
     @AfterAll
     static void teardown() {
+        client.close();
         client1.close();
         client2.close();
     }

--- a/javascript/cluster_management/README.md
+++ b/javascript/cluster_management/README.md
@@ -72,7 +72,7 @@ Files in the [/src](src) directory have a main() method that lets you exercise s
 
 ```
 # Check each operation for its expected environment variables
-REGION_1="us-east-1" CLUSTER_ID="<your cluster id>" \
+CLUSTER_1_REGION="us-east-1" CLUSTER_ID="<your cluster id>" \
 node ./src/get_cluster.js
 ```
 

--- a/javascript/cluster_management/README.md
+++ b/javascript/cluster_management/README.md
@@ -72,7 +72,7 @@ Files in the [/src](src) directory have a main() method that lets you exercise s
 
 ```
 # Check each operation for its expected environment variables
-CLUSTER_1_REGION="us-east-1" CLUSTER_ID="<your cluster id>" \
+CLUSTER_REGION="us-east-1" CLUSTER_ID="<your cluster id>" \
 node ./src/get_cluster.js
 ```
 

--- a/javascript/cluster_management/test/index.test.js
+++ b/javascript/cluster_management/test/index.test.js
@@ -9,7 +9,7 @@ const timeout = 600 * 1000; // 10 minutes in milliseconds
 
 test('Single region cluster test', async function () {
 
-    const region = 'us-east-1';
+    const region = process.env.CLUSTER_REGION || 'us-east-1';
 
     console.log("Starting single region cluster lifecycle run");
     let cluster = await createCluster(region);

--- a/python/cluster_management/README.md
+++ b/python/cluster_management/README.md
@@ -13,11 +13,11 @@ in [`test_dsql_cluster_management.py`](test/test_dsql_cluster_management.py).
 
 ### ⚠️ Important
 
-* Running this code might result in charges to your AWS account.
-* We recommend that you grant your code least privilege. At most, grant only the
+- Running this code might result in charges to your AWS account.
+- We recommend that you grant your code least privilege. At most, grant only the
   minimum permissions required to perform the task. For more information, see
   [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
-* This code is not tested in every AWS Region. For more information, see
+- This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
 ### Prerequisites
@@ -28,13 +28,13 @@ in [`test_dsql_cluster_management.py`](test/test_dsql_cluster_management.py).
 ### Execute tests to create and delete clusters
 
 ```sh
-# Optional: Single-Region examples will execute in REGION_1. Defaults to 'us-east-1'.
-export REGION_1="us-east-1"
+# Optional: Single-Region examples will execute in CLUSTER_1_REGION. Defaults to 'us-east-1'.
+export CLUSTER_1_REGION="us-east-1"
 
-# Optional: Multi-Region examples will create clusters in REGION_1 and REGION_2
-# with WITNESS_REGION as witness for both. Defaults to 'us-east-2' for REGION_2
+# Optional: Multi-Region examples will create clusters in CLUSTER_1_REGION and CLUSTER_2_REGION
+# with WITNESS_REGION as witness for both. Defaults to 'us-east-2' for CLUSTER_2_REGION
 # and 'us-west-2' for WITNESS_REGION.
-export REGION_2="us-east-2"
+export CLUSTER_2_REGION="us-east-2"
 export WITNESS_REGION="us-west-2"
 
 python3 -m venv .venv && source .venv/bin/activate
@@ -47,11 +47,12 @@ pytest test/test_dsql_cluster_management.py [-s]
 Test execution will take around five minutes as it waits for clusters to complete activation and deletion.
 
 ### Executing single operations
+
 Files in [src/](src/) each have a `main()` function that let you exercise single operations.
 
 ```shell
 # Check each operation for its expected environment variables
-REGION_1="us-east-1" CLUSTER_ID_1="<your cluster id>" \
+CLUSTER_1_REGION="us-east-1" CLUSTER_1_ID="<your cluster id>" \
   python src/get_cluster.py
 ```
 

--- a/python/cluster_management/README.md
+++ b/python/cluster_management/README.md
@@ -28,12 +28,13 @@ in [`test_dsql_cluster_management.py`](test/test_dsql_cluster_management.py).
 ### Execute tests to create and delete clusters
 
 ```sh
-# Optional: Single-Region examples will execute in CLUSTER_1_REGION. Defaults to 'us-east-1'.
-export CLUSTER_1_REGION="us-east-1"
+# Optional: Single-Region examples will execute in CLUSTER_REGION. Defaults to 'us-east-1'.
+export CLUSTER_REGION="us-east-1"
 
 # Optional: Multi-Region examples will create clusters in CLUSTER_1_REGION and CLUSTER_2_REGION
 # with WITNESS_REGION as witness for both. Defaults to 'us-east-2' for CLUSTER_2_REGION
 # and 'us-west-2' for WITNESS_REGION.
+export CLUSTER_1_REGION="us-east-1"
 export CLUSTER_2_REGION="us-east-2"
 export WITNESS_REGION="us-west-2"
 
@@ -52,7 +53,7 @@ Files in [src/](src/) each have a `main()` function that let you exercise single
 
 ```shell
 # Check each operation for its expected environment variables
-CLUSTER_1_REGION="us-east-1" CLUSTER_1_ID="<your cluster id>" \
+CLUSTER_REGION="us-east-1" CLUSTER_ID="<your cluster id>" \
   python src/get_cluster.py
 ```
 

--- a/python/cluster_management/src/create_multi_region.py
+++ b/python/cluster_management/src/create_multi_region.py
@@ -58,8 +58,8 @@ def create_multi_region_clusters(region_1, region_2, witness_region):
 
 
 def main():
-    region_1 = os.environ.get("REGION_1", "us-east-1")
-    region_2 = os.environ.get("REGION_2", "us-east-2")
+    region_1 = os.environ.get("CLUSTER_1_REGION", "us-east-1")
+    region_2 = os.environ.get("CLUSTER_2_REGION", "us-east-2")
     witness_region = os.environ.get("WITNESS_REGION", "us-west-2")
     (cluster_1, cluster_2) = create_multi_region_clusters(region_1, region_2, witness_region)
     print("Created multi region clusters:")

--- a/python/cluster_management/src/create_single_region.py
+++ b/python/cluster_management/src/create_single_region.py
@@ -25,7 +25,7 @@ def create_cluster(region):
 
 
 def main():
-    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
+    region = os.environ.get("CLUSTER_REGION", "us-east-1")
     response = create_cluster(region)
     print(f"Created cluster: {response['arn']}")
 

--- a/python/cluster_management/src/create_single_region.py
+++ b/python/cluster_management/src/create_single_region.py
@@ -25,7 +25,7 @@ def create_cluster(region):
 
 
 def main():
-    region = os.environ.get("REGION_1", "us-east-1")
+    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
     response = create_cluster(region)
     print(f"Created cluster: {response['arn']}")
 

--- a/python/cluster_management/src/delete_multi_region.py
+++ b/python/cluster_management/src/delete_multi_region.py
@@ -42,12 +42,12 @@ def delete_multi_region_clusters(region_1, cluster_id_1, region_2, cluster_id_2)
 
 
 def main():
-    region_1 = os.environ.get("REGION_1", "us-east-1")
-    cluster_id_1 = os.environ.get("CLUSTER_ID_1")
-    assert cluster_id_1 is not None, "Must provide CLUSTER_ID_1"
-    region_2 = os.environ.get("REGION_2", "us-east-2")
-    cluster_id_2 = os.environ.get("CLUSTER_ID_2")
-    assert cluster_id_2 is not None, "Must provide CLUSTER_ID_2"
+    region_1 = os.environ.get("CLUSTER_1_REGION", "us-east-1")
+    cluster_id_1 = os.environ.get("CLUSTER_1_ID")
+    assert cluster_id_1 is not None, "Must provide CLUSTER_1_ID"
+    region_2 = os.environ.get("CLUSTER_2_REGION", "us-east-2")
+    cluster_id_2 = os.environ.get("CLUSTER_2_ID")
+    assert cluster_id_2 is not None, "Must provide CLUSTER_2_ID"
 
     delete_multi_region_clusters(region_1, cluster_id_1, region_2, cluster_id_2)
     print(f"Deleted {cluster_id_1} in {region_1} and {cluster_id_2} in {region_2}")

--- a/python/cluster_management/src/delete_single_region.py
+++ b/python/cluster_management/src/delete_single_region.py
@@ -22,9 +22,9 @@ def delete_cluster(region, identifier):
 
 
 def main():
-    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
-    cluster_id = os.environ.get("CLUSTER_1_ID")
-    assert cluster_id is not None, "Must provide CLUSTER_1_ID"
+    region = os.environ.get("CLUSTER_REGION", "us-east-1")
+    cluster_id = os.environ.get("CLUSTER_ID")
+    assert cluster_id is not None, "Must provide CLUSTER_ID"
     delete_cluster(region, cluster_id)
     print(f"Deleted {cluster_id}")
 

--- a/python/cluster_management/src/delete_single_region.py
+++ b/python/cluster_management/src/delete_single_region.py
@@ -22,9 +22,9 @@ def delete_cluster(region, identifier):
 
 
 def main():
-    region = os.environ.get("REGION_1", "us-east-1")
-    cluster_id = os.environ.get("CLUSTER_ID_1")
-    assert cluster_id is not None, "Must provide CLUSTER_ID_1"
+    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
+    cluster_id = os.environ.get("CLUSTER_1_ID")
+    assert cluster_id is not None, "Must provide CLUSTER_1_ID"
     delete_cluster(region, cluster_id)
     print(f"Deleted {cluster_id}")
 

--- a/python/cluster_management/src/get_cluster.py
+++ b/python/cluster_management/src/get_cluster.py
@@ -14,9 +14,9 @@ def get_cluster(region, identifier):
 
 
 def main():
-    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
-    cluster_id = os.environ.get("CLUSTER_1_ID")
-    assert cluster_id is not None, "Must provide CLUSTER_1_ID"
+    region = os.environ.get("CLUSTER_REGION", "us-east-1")
+    cluster_id = os.environ.get("CLUSTER_ID")
+    assert cluster_id is not None, "Must provide CLUSTER_ID"
     response = get_cluster(region, cluster_id)
 
     print(json.dumps(response, indent=2, default=lambda obj: obj.isoformat() if isinstance(obj, datetime) else None))

--- a/python/cluster_management/src/get_cluster.py
+++ b/python/cluster_management/src/get_cluster.py
@@ -14,9 +14,9 @@ def get_cluster(region, identifier):
 
 
 def main():
-    region = os.environ.get("REGION_1", "us-east-1")
-    cluster_id = os.environ.get("CLUSTER_ID_1")
-    assert cluster_id is not None, "Must provide CLUSTER_ID_1"
+    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
+    cluster_id = os.environ.get("CLUSTER_1_ID")
+    assert cluster_id is not None, "Must provide CLUSTER_1_ID"
     response = get_cluster(region, cluster_id)
 
     print(json.dumps(response, indent=2, default=lambda obj: obj.isoformat() if isinstance(obj, datetime) else None))

--- a/python/cluster_management/src/update_cluster.py
+++ b/python/cluster_management/src/update_cluster.py
@@ -12,9 +12,9 @@ def update_cluster(region, cluster_id, deletion_protection_enabled):
 
 
 def main():
-    region = os.environ.get("REGION_1", "us-east-1")
-    cluster_id = os.environ.get("CLUSTER_ID_1")
-    assert cluster_id is not None, "Must provide CLUSTER_ID_1"
+    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
+    cluster_id = os.environ.get("CLUSTER_1_ID")
+    assert cluster_id is not None, "Must provide CLUSTER_1_ID"
     deletion_protection_enabled = False
     response = update_cluster(region, cluster_id, deletion_protection_enabled)
     print(f"Updated {response['arn']} with deletion_protection_enabled: {deletion_protection_enabled}")

--- a/python/cluster_management/src/update_cluster.py
+++ b/python/cluster_management/src/update_cluster.py
@@ -12,9 +12,9 @@ def update_cluster(region, cluster_id, deletion_protection_enabled):
 
 
 def main():
-    region = os.environ.get("CLUSTER_1_REGION", "us-east-1")
-    cluster_id = os.environ.get("CLUSTER_1_ID")
-    assert cluster_id is not None, "Must provide CLUSTER_1_ID"
+    region = os.environ.get("CLUSTER_REGION", "us-east-1")
+    cluster_id = os.environ.get("CLUSTER_ID")
+    assert cluster_id is not None, "Must provide CLUSTER_ID"
     deletion_protection_enabled = False
     response = update_cluster(region, cluster_id, deletion_protection_enabled)
     print(f"Updated {response['arn']} with deletion_protection_enabled: {deletion_protection_enabled}")

--- a/python/cluster_management/test/test_dsql_cluster_management.py
+++ b/python/cluster_management/test/test_dsql_cluster_management.py
@@ -9,8 +9,8 @@ import boto3
 import os
 import pytest
 
-region_1 = os.environ.get("REGION_1", "us-east-1")
-region_2 = os.environ.get("REGION_2", "us-east-2")
+region_1 = os.environ.get("CLUSTER_1_REGION", "us-east-1")
+region_2 = os.environ.get("CLUSTER_2_REGION", "us-east-2")
 witness_region = os.environ.get("WITNESS_REGION", "us-west-2")
 
 

--- a/python/cluster_management/test/test_dsql_cluster_management.py
+++ b/python/cluster_management/test/test_dsql_cluster_management.py
@@ -9,6 +9,7 @@ import boto3
 import os
 import pytest
 
+region = os.environ.get("CLUSTER_REGION", "us-east-1")
 region_1 = os.environ.get("CLUSTER_1_REGION", "us-east-1")
 region_2 = os.environ.get("CLUSTER_2_REGION", "us-east-2")
 witness_region = os.environ.get("WITNESS_REGION", "us-west-2")
@@ -17,21 +18,21 @@ witness_region = os.environ.get("WITNESS_REGION", "us-west-2")
 def test_single_region():
     try:
         print("Running single region test.")
-        cluster = create_cluster(region_1)
+        cluster = create_cluster(region)
         cluster_id = cluster["identifier"]
         assert cluster_id is not None
 
-        get_response = get_cluster(region_1, cluster_id)
+        get_response = get_cluster(region, cluster_id)
         assert get_response["arn"] is not None
         assert get_response["deletionProtectionEnabled"] is True
 
-        update_cluster(region_1, cluster_id, deletion_protection_enabled=False)
+        update_cluster(region, cluster_id, deletion_protection_enabled=False)
 
-        get_response = get_cluster(region_1, cluster_id)
+        get_response = get_cluster(region, cluster_id)
         assert get_response["arn"] is not None
         assert get_response["deletionProtectionEnabled"] is False
 
-        delete_cluster(region_1, cluster_id)
+        delete_cluster(region, cluster_id)
     except Exception as e:
         pytest.fail(f"Unexpected exception: {e}")
 

--- a/ruby/cluster_management/lib/create_single_region_cluster.rb
+++ b/ruby/cluster_management/lib/create_single_region_cluster.rb
@@ -25,7 +25,7 @@ rescue Aws::Errors::ServiceError => e
 end
 
 def main
-  region = ENV.fetch("CLUSTER_1_REGION", "us-east-1")
+  region = ENV.fetch("CLUSTER_REGION", "us-east-1")
   cluster = create_cluster(region)
   pp cluster
 end


### PR DESCRIPTION
- renamed all env variables to use the standard ones 

Single Cluster 
- CLUSTER_REGION
- CLUSTER_ID

Multi Clusters 
- CLUSTER_1_REGION  
- CLUSTER_2_REGION  
- WITNESS_REGION
- CLUSTER_1_ID
- CLUSTER_2_ID

By submitting this pull request, I confirm that my contribution is made under 
the terms of the MIT-0 license.

Thank you for your contribution!