### PR TITLE
go: Remove unnecessary region options

### DIFF
--- a/go/cluster_management/cmd/create_multi_region/create_multi_region.go
+++ b/go/cluster_management/cmd/create_multi_region/create_multi_region.go
@@ -22,9 +22,7 @@ func CreateMultiRegionClusters(ctx context.Context, witness, region1, region2 st
 	}
 
 	// Create a DSQL region 1 client
-	client := dsql.NewFromConfig(cfg, func(o *dsql.Options) {
-		o.Region = region1
-	})
+	client := dsql.NewFromConfig(cfg)
 
 	cfg2, err := config.LoadDefaultConfig(ctx, config.WithRegion(region2))
 	if err != nil {
@@ -32,9 +30,7 @@ func CreateMultiRegionClusters(ctx context.Context, witness, region1, region2 st
 	}
 
 	// Create a DSQL region 2 client
-	client2 := dsql.NewFromConfig(cfg2, func(o *dsql.Options) {
-		o.Region = region2
-	})
+	client2 := dsql.NewFromConfig(cfg2)
 
 	// Create cluster
 	deleteProtect := true

--- a/go/cluster_management/cmd/create_single_region/create_single_region.go
+++ b/go/cluster_management/cmd/create_single_region/create_single_region.go
@@ -20,10 +20,7 @@ func CreateCluster(ctx context.Context, region string) error {
 	}
 
 	// Create a DSQL client
-	client := dsql.NewFromConfig(cfg, func(o *dsql.Options) {
-		// For internal test only not required for prod.
-		o.Region = region
-	})
+	client := dsql.NewFromConfig(cfg)
 
 	deleteProtect := true
 

--- a/go/pgx/example.go
+++ b/go/pgx/example.go
@@ -55,10 +55,7 @@ func NewDSQLClient(ctx context.Context, region string) (*dsql.Client, error) {
 	}
 
 	// Create a DSQL client using NewFromConfig
-	dsqlClient := dsql.NewFromConfig(cfg, func(o *dsql.Options) {
-		// For internal test only not required for prod.
-		o.Region = region
-	})
+	dsqlClient := dsql.NewFromConfig(cfg)
 
 	return dsqlClient, nil
 }


### PR DESCRIPTION
They're already set by `config.WithRegion`

---

By submitting this pull request, I confirm that my contribution is made under 
the terms of the MIT-0 license.

Thank you for your contribution!