### PR TITLE
Limit cluster management job concurrency

### DIFF
--- a/.github/workflows/cpp-cm-integ-tests.yml
+++ b/.github/workflows/cpp-cm-integ-tests.yml
@@ -78,6 +78,9 @@ jobs:
         WITNESS_REGION: us-west-2
       run: |
         ./example
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -90,3 +93,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/dotnet-cm-integ-tests.yml
+++ b/.github/workflows/dotnet-cm-integ-tests.yml
@@ -48,6 +48,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
     steps:
       - name: Checkout code
@@ -80,3 +83,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/go-cm-integ-tests.yml
+++ b/.github/workflows/go-cm-integ-tests.yml
@@ -90,6 +90,9 @@ jobs:
       run: |
         go env -w GOPROXY=direct
         go test
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -102,3 +105,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/java-cm-integ-tests.yml
+++ b/.github/workflows/java-cm-integ-tests.yml
@@ -57,6 +57,9 @@ jobs:
         mvn initialize
         mvn clean compile assembly:single
         mvn test
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -69,3 +72,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/javascript-cm-integ-tests.yml
+++ b/.github/workflows/javascript-cm-integ-tests.yml
@@ -52,6 +52,9 @@ jobs:
         run: |
           npm install
           npm test
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -64,3 +67,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/python-cm-integ-tests.yml
+++ b/.github/workflows/python-cm-integ-tests.yml
@@ -65,6 +65,9 @@ jobs:
         pip list
         echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
         pytest -v test/
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -77,3 +80,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/ruby-cm-integ-tests.yml
+++ b/.github/workflows/ruby-cm-integ-tests.yml
@@ -51,6 +51,9 @@ jobs:
       run: |
         bundle install
         rspec
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -63,3 +66,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}

--- a/.github/workflows/rust-cm-integ-tests.yml
+++ b/.github/workflows/rust-cm-integ-tests.yml
@@ -65,6 +65,9 @@ jobs:
         working-directory: ./rust/cluster_management
         run: |
           cargo test -- --nocapture
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
   cleanup:
     if: always()
@@ -77,3 +80,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}


### PR DESCRIPTION
This PR modifies the cluster management workflows to ensure only 1 job runs at any given time against each account. This will help prevent conflicts where the cluster cleanup job deletes clusters that are being used by a testing job.

I could have put the `concurrency` limit on the workflow, which would ensure all jobs and cleanup steps finish before any other workflow can begin. I chose to put it on the `job` here instead, so that other tasks like formatting checks can complete and provide quick feedback in the PR without having to potentially wait for other workflows to finish.

I tested this change by running 2 of the same workflow, and we can see here the job is waiting before proceeding since there is already a job running. We can also see the formatting check was not blocked.

![image](https://github.com/user-attachments/assets/450191f1-50aa-4b45-a79a-caccb914a2da)

There is a small risk in the following scenario:

- there are a bunch of jobs all queued up at the same time for the same test suite
- the tests are broken and don't clean up clusters
- all testing jobs schedule themselves before all cleanup jobs

If this happens then we could run out of cluster space in the account, and fail some later jobs in the queue which would otherwise have succeeded. If that happens then the cluster cleanup jobs will eventually run once all of the test jobs fail and fix the state of the account, and we can rerun any jobs that should have passed after that. It seems unlikely this will happen anyway given the prerequisites.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.