### PR TITLE
Move GOPROXY definition to top level of workflows

### DIFF
--- a/.github/workflows/go-cm-integ-tests.yml
+++ b/.github/workflows/go-cm-integ-tests.yml
@@ -30,6 +30,8 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    env:
+      GOPROXY: direct
 
     steps:
     - uses: actions/checkout@v4
@@ -63,32 +65,26 @@ jobs:
     - name: Build & Run Create Multi region
       working-directory: ./go/cluster_management/cmd/create_multi_region
       run: |
-        go env -w GOPROXY=direct
         go test
     - name: Build & Run Create Single region
       working-directory: ./go/cluster_management/cmd/create_single_region
       run: |
-        go env -w GOPROXY=direct
         go test
     - name: Build & Run Get Cluster
       working-directory: ./go/cluster_management/cmd/get_cluster
       run: |
-        go env -w GOPROXY=direct
         go test
     - name: Build & Run Update Cluster
       working-directory: ./go/cluster_management/cmd/update_cluster
       run: |
-        go env -w GOPROXY=direct
         go test
     - name: Build & Run Delete Single region
       working-directory: ./go/cluster_management/cmd/delete_single_region
       run: |
-        go env -w GOPROXY=direct
         go test
     - name: Build & Run Delete Multi region
       working-directory: ./go/cluster_management/cmd/delete_multi_region
       run: |
-        go env -w GOPROXY=direct
         go test
     concurrency:
       # Ensure only 1 job mutates clusters in this account at a time.

--- a/.github/workflows/go-pgx-integ-tests.yml
+++ b/.github/workflows/go-pgx-integ-tests.yml
@@ -30,6 +30,8 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    env:
+      GOPROXY: direct
 
     steps:
     - uses: actions/checkout@v4
@@ -51,5 +53,4 @@ jobs:
         CLUSTER_ENDPOINT: ${{ secrets.GO_PGX_CLUSTER_ENDPOINT }}
         REGION: ${{ secrets.GO_PGX_CLUSTER_REGION }}
       run: |
-        go env -w GOPROXY=direct
         go test -v


### PR DESCRIPTION
This PR moves the `GOPROXY=direct` definition to a higher level in the workflows, to ensure it applies to the entire setup process.

While testing the action locally I noticed several of the setup steps were having trouble with blocked proxy calls. This was happening before we got to the `GOPROXY` definition, which indicated there were actions which weren't covered by the variable definition.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.