### PR TITLE
Trigger workflows on changes to clean-clusters.yml

### DIFF
--- a/.github/workflows/cpp-cm-integ-tests.yml
+++ b/.github/workflows/cpp-cm-integ-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'cpp/cluster_management/**'
       - '.github/workflows/cpp-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'cpp/cluster_management/**'
       - '.github/workflows/cpp-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/dotnet-cm-integ-tests.yml
+++ b/.github/workflows/dotnet-cm-integ-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'dotnet/cluster_management/**'
       - '.github/workflows/dotnet-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'dotnet/cluster_management/**'
       - '.github/workflows/dotnet-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/go-cm-integ-tests.yml
+++ b/.github/workflows/go-cm-integ-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'go/cluster_management/**'
       - '.github/workflows/go-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   pull_request:
     branches: [ "main" ]
     paths:
       - 'go/cluster_management/**'
       - '.github/workflows/go-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/java-cm-integ-tests.yml
+++ b/.github/workflows/java-cm-integ-tests.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'java/cluster_management/**'
       - '.github/workflows/java-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
 
   pull_request:
     branches: [ "main" ]
     paths:
       - 'java/cluster_management/**'
       - '.github/workflows/java-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
 
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:

--- a/.github/workflows/javascript-cm-integ-tests.yml
+++ b/.github/workflows/javascript-cm-integ-tests.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - "javascript/cluster_management/**"
       - ".github/workflows/javascript-cm-integ-tests.yml"
+      - '.github/workflows/clean-clusters.yml'
 
   pull_request:
     branches: ["main"]
     paths:
       - "javascript/cluster_management/**"
       - ".github/workflows/javascript-cm-integ-tests.yml"
+      - '.github/workflows/clean-clusters.yml'
 
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:

--- a/.github/workflows/python-cm-integ-tests.yml
+++ b/.github/workflows/python-cm-integ-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'python/cluster_management/**'
       - '.github/workflows/python-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'python/cluster_management/**'
       - '.github/workflows/python-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/ruby-cm-integ-tests.yml
+++ b/.github/workflows/ruby-cm-integ-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'ruby/cluster_management/**'
       - '.github/workflows/ruby-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'ruby/cluster_management/**'
       - '.github/workflows/ruby-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
     inputs:

--- a/.github/workflows/rust-cm-integ-tests.yml
+++ b/.github/workflows/rust-cm-integ-tests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'rust/cluster_management/**'
       - '.github/workflows/rust-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   pull_request:
     branches: [ main ]
     paths:
       - 'rust/cluster_management/**'
       - '.github/workflows/rust-cm-integ-tests.yml'
+      - '.github/workflows/clean-clusters.yml'
   # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This PR ensures we run all affected workflows if the `.github/workflows/clean-clusters.yml` file changes.

This should have been included in #144 but I missed it there.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.