### PR TITLE
cpp: Run cpp workflows faster

### DIFF
--- a/.github/workflows/cpp-cm-integ-tests.yml
+++ b/.github/workflows/cpp-cm-integ-tests.yml
@@ -57,8 +57,8 @@ jobs:
         mkdir aws-sdk-build
         mkdir aws-sdk-install
         cd aws-sdk-build
-        cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/cpp/cluster_management/aws-sdk-install -DBUILD_ONLY="dsql"
-        cmake --build . --config=Release
+        cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/cpp/cluster_management/aws-sdk-install -DBUILD_ONLY="dsql"
+        cmake --build . --config=Release --parallel $(nproc)
         cmake --install . --config=Release
 
     - name: Configure AWS Credentials

--- a/.github/workflows/cpp-libpq-integ-tests.yml
+++ b/.github/workflows/cpp-libpq-integ-tests.yml
@@ -58,8 +58,8 @@ jobs:
         mkdir aws-sdk-build
         mkdir aws-sdk-install
         cd aws-sdk-build
-        cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/cpp/libpq/aws-sdk-install -DBUILD_ONLY="dsql"
-        cmake --build . --config=Release
+        cmake ../aws-sdk-cpp -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/cpp/libpq/aws-sdk-install -DBUILD_ONLY="dsql"
+        cmake --build . --config=Release --parallel $(nproc)
         cmake --install . --config=Release
 
     - name: Configure AWS Credentials


### PR DESCRIPTION
This PR updates the C++ workflows to improve the runtime.

The following changes are included:
- Run the build in parallel given the number of processors allocated to the worker
- Disable tests in third-party dependencies

This improves the time it takes to install the AWS SDK from ~8:30 to ~3 minutes.

These changes will have less of an effect on the cluster management tests since the test run there takes a significant amount of time by itself. It will have more of an effect on the `libpq` tests since the test runtime for those is near instant.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.