### PR TITLE
cpp: Use verify-full for libpq sample

### DIFF
--- a/.github/workflows/cpp-libpq-integ-tests.yml
+++ b/.github/workflows/cpp-libpq-integ-tests.yml
@@ -80,4 +80,5 @@ jobs:
         CLUSTER_USER: admin
         LD_LIBRARY_PATH: /lib/x86_64-linux-gnu:/home/runner/work/aurora-dsql-samples/aurora-dsql-samples/cpp/libpq/aws-sdk-install/lib
       run: |
+        wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem
         ./libpq_example

--- a/cpp/libpq/README.md
+++ b/cpp/libpq/README.md
@@ -47,6 +47,13 @@ The example contains comments explaining the code and the operations being perfo
   [Using database roles with IAM roles](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/using-database-and-iam-roles.html)
   guide.
 
+### Download the Amazon root certificate from the official trust store
+
+Download the Amazon root certificate from the official trust store:
+
+```
+wget https://www.amazontrust.com/repository/AmazonRootCA1.pem -O root.pem
+```
 
 #### C++ compiler 
 A c++ compiler that supports c++11 standard or newer.

--- a/cpp/libpq/src/libpq_example.cpp
+++ b/cpp/libpq/src/libpq_example.cpp
@@ -32,7 +32,8 @@ std::string generateDBAuthToken(const std::string clusterUser, const std::string
 
 PGconn* connectToCluster(std::string clusterUser, std::string clusterEndpoint, std::string region) {
     std::string dbname = "postgres";
-    std::string sslmode = "require";
+    std::string sslrootcert = "./root.pem";
+    std::string sslmode = "verify-full";
     int port = 5432;
 
     // Generate a fresh password token for each connection, to ensure the token is not expired
@@ -45,8 +46,8 @@ PGconn* connectToCluster(std::string clusterUser, std::string clusterEndpoint, s
     } 
 
     char conninfo[4096];
-    sprintf(conninfo, "dbname=%s user=%s host=%s port=%i sslmode=%s password=%s", 
-            dbname.c_str(), clusterUser.c_str(), clusterEndpoint.c_str(), port, sslmode.c_str(), password_token.c_str());
+    sprintf(conninfo, "dbname=%s user=%s host=%s port=%i sslrootcert=%s sslmode=%s password=%s",
+            dbname.c_str(), clusterUser.c_str(), clusterEndpoint.c_str(), port, sslrootcert.c_str(), sslmode.c_str(), password_token.c_str());
 
     PGconn *conn = PQconnectdb(conninfo);
 


### PR DESCRIPTION
This PR configures the `libpq` sample to use `verify-full` instead of `require` for a more secure TLS connection.

In order to configure the trusted certificate, we must download it as part of the build. This aligns the `libpq` sample with other samples which download and verify the server certificate.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.