### PR TITLE
cpp: Use direct TLS connections for libpq

### DIFF
--- a/cpp/libpq/README.md
+++ b/cpp/libpq/README.md
@@ -30,6 +30,18 @@ The example contains comments explaining the code and the operations being perfo
 * This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
 
 ## Run the example
 

--- a/cpp/libpq/src/libpq_example.cpp
+++ b/cpp/libpq/src/libpq_example.cpp
@@ -34,6 +34,7 @@ PGconn* connectToCluster(std::string clusterUser, std::string clusterEndpoint, s
     std::string dbname = "postgres";
     std::string sslrootcert = "./root.pem";
     std::string sslmode = "verify-full";
+    std::string sslnegotiation = "direct";
     int port = 5432;
 
     // Generate a fresh password token for each connection, to ensure the token is not expired
@@ -46,8 +47,16 @@ PGconn* connectToCluster(std::string clusterUser, std::string clusterEndpoint, s
     } 
 
     char conninfo[4096];
-    sprintf(conninfo, "dbname=%s user=%s host=%s port=%i sslrootcert=%s sslmode=%s password=%s",
-            dbname.c_str(), clusterUser.c_str(), clusterEndpoint.c_str(), port, sslrootcert.c_str(), sslmode.c_str(), password_token.c_str());
+    sprintf(conninfo,
+            "dbname=%s user=%s host=%s port=%i sslrootcert=%s sslmode=%s sslnegotiation=%s password=%s",
+            dbname.c_str(),
+            clusterUser.c_str(),
+            clusterEndpoint.c_str(),
+            port,
+            sslrootcert.c_str(),
+            sslmode.c_str(),
+            sslnegotiation.c_str(),
+            password_token.c_str());
 
     PGconn *conn = PQconnectdb(conninfo);
 


### PR DESCRIPTION
This PR modifies the `libpq` example to set `sslnegotiation=direct` as per #150.

I added a section to the `README.md` file which describes more about the TLS configuration, and calls out that direct TLS connections are a new feature and may not be supported by all driver versions. My intention is to add the same section to the `README.md` files of other drivers as they are updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.