### PR TITLE
java: Use direct TLS connections for pgJDBC

### DIFF
--- a/java/pgjdbc/README.md
+++ b/java/pgjdbc/README.md
@@ -29,6 +29,19 @@ The code automatically detects the user type and adjusts its behavior accordingl
 * This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
 ## Run the example
 
 ### Prerequisites

--- a/java/pgjdbc/src/main/java/org/example/Example.java
+++ b/java/pgjdbc/src/main/java/org/example/Example.java
@@ -45,6 +45,7 @@ public class Example {
         // to verify the server's root cert.
         props.setProperty("sslmode", "verify-full");
         props.setProperty("sslfactory", "org.postgresql.ssl.DefaultJavaSSLFactory");
+        props.setProperty("sslNegotiation", "direct");
 
         String url = "jdbc:postgresql://" + endpoint + ":5432/postgres";
 


### PR DESCRIPTION
This PR modifies the `pgJDBC` example to set `sslNegotiation=direct` as per #150.

I added a section to the `README.md` file which describes more about the TLS configuration, and calls out that direct TLS connections are a new feature and may not be supported by all driver versions. My intention is to add the same section to the `README.md` files of other drivers as they are updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.