### PR TITLE
Limit sample concurrency to prevent cluster usage conflicts

### DIFF
--- a/.github/workflows/cpp-libpq-integ-tests.yml
+++ b/.github/workflows/cpp-libpq-integ-tests.yml
@@ -29,6 +29,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/dotnet-npgsql-integ-tests.yml
+++ b/.github/workflows/dotnet-npgsql-integ-tests.yml
@@ -31,6 +31,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/go-pgx-integ-tests.yml
+++ b/.github/workflows/go-pgx-integ-tests.yml
@@ -30,6 +30,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
     env:
       GOPROXY: direct
 

--- a/.github/workflows/java-pgjdbc-integ-tests.yml
+++ b/.github/workflows/java-pgjdbc-integ-tests.yml
@@ -29,7 +29,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/javascript-node-postgres-integ-tests.yml
+++ b/.github/workflows/javascript-node-postgres-integ-tests.yml
@@ -29,7 +29,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/javascript-postgresjs-integ-tests.yml
+++ b/.github/workflows/javascript-postgresjs-integ-tests.yml
@@ -29,6 +29,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/python-psycopg2-integ-tests.yml
+++ b/.github/workflows/python-psycopg2-integ-tests.yml
@@ -29,7 +29,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/python-psycopg3-integ-tests.yml
+++ b/.github/workflows/python-psycopg3-integ-tests.yml
@@ -29,7 +29,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/python-sqlalchemy-integ-tests.yml
+++ b/.github/workflows/python-sqlalchemy-integ-tests.yml
@@ -29,7 +29,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/ruby-rubypg-integ-tests.yml
+++ b/.github/workflows/ruby-rubypg-integ-tests.yml
@@ -29,7 +29,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/rust-sqlx-integ-test.yml
+++ b/.github/workflows/rust-sqlx-integ-test.yml
@@ -30,7 +30,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/typescript-sequelize-integ-tests.yml
+++ b/.github/workflows/typescript-sequelize-integ-tests.yml
@@ -31,6 +31,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/typescript-type-orm-integ-tests.yml
+++ b/.github/workflows/typescript-type-orm-integ-tests.yml
@@ -29,6 +29,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job uses the workflow cluster at a time.
+      group: ${{ github.workflow }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This PR updates the workflow definitions for the various drivers to ensure only 1 job runs at a time for each workflow.

Since the workflows use a statically configured cluster, any attempts to run 2 jobs against the same cluster at the same time may result in conflicts and failed jobs. By configuring the `concurrency` property we can instruct jobs to wait until previous jobs for the same workflow are complete.

Related: #149 

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.