### PR TITLE
Configure cluster management concurrency in a consistent place

### DIFF
--- a/.github/workflows/cpp-cm-integ-tests.yml
+++ b/.github/workflows/cpp-cm-integ-tests.yml
@@ -31,6 +31,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
     steps:
     - name: Checkout code
@@ -80,9 +83,6 @@ jobs:
         WITNESS_REGION: us-west-2
       run: |
         ./example
-    concurrency:
-      # Ensure only 1 job mutates clusters in this account at a time.
-      group: ${{ github.workflow }}
 
   cleanup:
     if: always()

--- a/.github/workflows/go-cm-integ-tests.yml
+++ b/.github/workflows/go-cm-integ-tests.yml
@@ -32,6 +32,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
     env:
       GOPROXY: direct
 
@@ -88,9 +91,6 @@ jobs:
       working-directory: ./go/cluster_management/cmd/delete_multi_region
       run: |
         go test
-    concurrency:
-      # Ensure only 1 job mutates clusters in this account at a time.
-      group: ${{ github.workflow }}
 
   cleanup:
     if: always()

--- a/.github/workflows/java-cm-integ-tests.yml
+++ b/.github/workflows/java-cm-integ-tests.yml
@@ -33,6 +33,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
     steps:
     - name: Checkout code
@@ -59,9 +62,6 @@ jobs:
         mvn initialize
         mvn clean compile assembly:single
         mvn test
-    concurrency:
-      # Ensure only 1 job mutates clusters in this account at a time.
-      group: ${{ github.workflow }}
 
   cleanup:
     if: always()

--- a/.github/workflows/javascript-cm-integ-tests.yml
+++ b/.github/workflows/javascript-cm-integ-tests.yml
@@ -33,6 +33,9 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
 
     steps:
       - name: Checkout code
@@ -54,9 +57,6 @@ jobs:
         run: |
           npm install
           npm test
-    concurrency:
-      # Ensure only 1 job mutates clusters in this account at a time.
-      group: ${{ github.workflow }}
 
   cleanup:
     if: always()

--- a/.github/workflows/python-cm-integ-tests.yml
+++ b/.github/workflows/python-cm-integ-tests.yml
@@ -31,7 +31,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -67,9 +70,6 @@ jobs:
         pip list
         echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
         pytest -v test/
-    concurrency:
-      # Ensure only 1 job mutates clusters in this account at a time.
-      group: ${{ github.workflow }}
 
   cleanup:
     if: always()

--- a/.github/workflows/ruby-cm-integ-tests.yml
+++ b/.github/workflows/ruby-cm-integ-tests.yml
@@ -31,7 +31,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -53,9 +56,6 @@ jobs:
       run: |
         bundle install
         rspec
-    concurrency:
-      # Ensure only 1 job mutates clusters in this account at a time.
-      group: ${{ github.workflow }}
 
   cleanup:
     if: always()

--- a/.github/workflows/rust-cm-integ-tests.yml
+++ b/.github/workflows/rust-cm-integ-tests.yml
@@ -49,7 +49,10 @@ jobs:
       actions: read
       checks: write
       pull-requests: write
-    
+    concurrency:
+      # Ensure only 1 job mutates clusters in this account at a time.
+      group: ${{ github.workflow }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,9 +70,6 @@ jobs:
         working-directory: ./rust/cluster_management
         run: |
           cargo test -- --nocapture
-    concurrency:
-      # Ensure only 1 job mutates clusters in this account at a time.
-      group: ${{ github.workflow }}
 
   cleanup:
     if: always()


### PR DESCRIPTION
This PR is a cosmetic change to the structure of the cluster management `.yml` files.

The concurrency blocks were added in #149, but while working on #162 I noticed they should really be grouped with the job configuration at the top. This was done inconsistently in #149 for some reason, with the .NET sample already grouping it at the top of the job configuration.

Having the `concurrency` block at the top makes it a bit easier to spot given the steps for the job are variable length and sometimes quite complex.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.