### PR TITLE
dotnet: Use direct TLS connections for Npgsql

### DIFF
--- a/dotnet/npgsql/Example.cs
+++ b/dotnet/npgsql/Example.cs
@@ -38,6 +38,7 @@ internal static class Example
             Host = clusterEndpoint,
             Port = 5432,
             SslMode = SslMode.VerifyFull,
+            SslNegotiation = SslNegotiation.Direct,
             Database = "postgres",
             Username = clusterUser,
             Password = password,

--- a/dotnet/npgsql/README.md
+++ b/dotnet/npgsql/README.md
@@ -29,6 +29,19 @@ The code automatically detects the user type and adjusts its behavior accordingl
 * This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
 ## Run the example
 
 ### Prerequisites

--- a/dotnet/npgsql/example.csproj
+++ b/dotnet/npgsql/example.csproj
@@ -3,8 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
 
-        <!-- We target both for compatibility -->
-        <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+        <TargetFramework>net9.0</TargetFramework>
         <LangVersion>10</LangVersion>
 
         <ImplicitUsings>enable</ImplicitUsings>
@@ -16,7 +15,7 @@
     <ItemGroup>
         <PackageReference Include="AWSSDK.Core" Version="4.0.0.3"/>
         <PackageReference Include="AWSSDK.DSQL" Version="4.0.1"/>
-        <PackageReference Include="Npgsql" Version="8.0.5"/>
+        <PackageReference Include="Npgsql" Version="9.0.3" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR modifies the `Npgsql` sample to set `SslNegotiation = SslNegotiation.Direct` as per #150.

Part of this change is removing support for `netstandard2.0`. We previously provided this for compatibility reasons, but `Npgsql` 9.0.3+ does not support `netstandard2.0` so we can't support .NET Framework while also using `SslNegotiation`. After offline discussion, it was decided we would prioritize the more secure/performant connection type, and those that need `netstandard2.0` can always use an older Npgsql version with the traditional PostgreSQL connection preamble.

I added a section to the `README.md` file which describes more about the TLS configuration, and calls out that direct TLS connections are a new feature and may not be supported by all driver versions. This section was already reviewed in #160, and will be added to all samples which support direct TLS connections.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.