### PR TITLE
python: Use direct TLS connections for psycopg

### DIFF
--- a/python/psycopg/README.md
+++ b/python/psycopg/README.md
@@ -29,6 +29,19 @@ The code automatically detects the user type and adjusts its behavior accordingl
 * This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
 ## Run the example
 
 ### Prerequisites

--- a/python/psycopg/src/example.py
+++ b/python/psycopg/src/example.py
@@ -2,6 +2,7 @@ import boto3
 import psycopg
 import os
 import sys
+from psycopg import pq
 
 
 def create_connection(cluster_user, cluster_endpoint, region):
@@ -27,6 +28,10 @@ def create_connection(cluster_user, cluster_endpoint, region):
         "sslrootcert": ssl_cert_path,
         "password": password_token
     }
+
+    # Use the more efficient connection method if it's supported.
+    if pq.version() >= 170000:
+        conn_params["sslnegotiation"] = "direct"
 
     # Make a connection to the cluster
     conn = psycopg.connect(**conn_params)


### PR DESCRIPTION
This PR modifies the `psycopg` sample to set `sslnegotiation=direct` as per #150.

It does this conditionally based on the underlying `libpq` version, since the same `psycopg` version can be used with multiple versions of `libpq`. I verified in the release notes [here](https://www.postgresql.org/docs/release/17.0/) that `sslnegotiation` has been available since the `17.0` release and was not added as a minor version bump.

I added a section to the `README.md` file which describes more about the TLS configuration, and calls out that direct TLS connections are a new feature and may not be supported by all driver versions. This section was already reviewed in #160, and will be added to all samples which support direct TLS connections.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.