### PR TITLE
python: Use direct TLS connections for psycopg2

### DIFF
--- a/python/psycopg2/README.md
+++ b/python/psycopg2/README.md
@@ -29,6 +29,19 @@ The code automatically detects the user type and adjusts its behavior accordingl
 * This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
 ## Run the example
 
 ### Prerequisites

--- a/python/psycopg2/src/example.py
+++ b/python/psycopg2/src/example.py
@@ -1,5 +1,6 @@
 import boto3
 import psycopg2
+import psycopg2.extensions
 import os
 import sys
 
@@ -23,6 +24,10 @@ def create_connection(cluster_user, cluster_endpoint, region):
         "sslrootcert": "./root.pem",
         "password": password_token
     }
+
+    # Use the more efficient connection method if it's supported.
+    if psycopg2.extensions.libpq_version() >= 170000:
+        conn_params["sslnegotiation"] = "direct"
 
     # Make a connection to the cluster
     conn = psycopg2.connect(**conn_params)


### PR DESCRIPTION
This PR modifies the `psycopg2` sample to set `sslnegotiation=direct` as per #150.

It does this conditionally based on the underlying `libpq` version, since the same `psycopg2` version can be used with multiple versions of `libpq`. I verified in the release notes [here](https://www.postgresql.org/docs/release/17.0/) that `sslnegotiation` has been available since the `17.0` release and was not added as a minor version bump.

At the time of writing, the `psycopg2-binary` package includes `libpq` 16.0, which doesn't support the `sslnegotiation` parameter. I manually checked a version of `psycopg2` compiled against `libpq` 17.4 and the direct TLS connection worked properly. I have kept the sample dependency on the pre-built binary, as it's more approachable in terms of the system requirement for running the sample. If/when `psycopg2-binary` is updated to include `libpq` 17.0+, it will start using `sslnegotiation` without any changes here.

I added a section to the `README.md` file which describes more about the TLS configuration, and calls out that direct TLS connections are a new feature and may not be supported by all driver versions. This section was already reviewed in #160, and will be added to all samples which support direct TLS connections.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.