### PR TITLE
ruby: Use direct TLS connections for ruby-pg

### DIFF
--- a/ruby/ruby-pg/README.md
+++ b/ruby/ruby-pg/README.md
@@ -30,6 +30,19 @@ The example contains comments explaining the code and the operations being perfo
 * This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
 ## Run the example
 
 ### Prerequisites

--- a/ruby/ruby-pg/lib/hello_dsql.rb
+++ b/ruby/ruby-pg/lib/hello_dsql.rb
@@ -22,16 +22,22 @@ def create_connection(cluster_user, cluster_endpoint, region)
     password_token = token_generator.generate_db_connect_auth_token(auth_token_params)
   end 
 
-  PG.connect(
-      host: cluster_endpoint,
-      user: cluster_user,
-      password: password_token,
-      dbname: 'postgres',
-      port: 5432,
-      sslmode: 'verify-full',
-      sslrootcert: "./root.pem"
-  )
+  conn_params = {
+    host: cluster_endpoint,
+    user: cluster_user,
+    password: password_token,
+    dbname: 'postgres',
+    port: 5432,
+    sslmode: 'verify-full',
+    sslrootcert: "./root.pem"
+  }
 
+  # Use the more efficient connection method if it's supported.
+  if PG::library_version >= 170000
+    conn_params[:sslnegotiation] = "direct"
+  end
+
+  PG.connect(conn_params)
 end
 
 def example(conn)


### PR DESCRIPTION
This PR modifies the `ruby-pg` sample to set `sslnegotiation=direct` as per #150.

It does this conditionally based on the underlying `libpq` version, since the same `ruby-pg` version can be used with multiple versions of `libpq`. I verified in the release notes [here](https://www.postgresql.org/docs/release/17.0/) that `sslnegotiation` has been available since the `17.0` release and was not added as a minor version bump.

I added a section to the `README.md` file which describes more about the TLS configuration, and calls out that direct TLS connections are a new feature and may not be supported by all driver versions. This section was already reviewed in #160, and will be added to all samples which support direct TLS connections.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.