### PR TITLE
ruby: Use direct TLS connections for Rails

### DIFF
--- a/ruby/rails/petclinic/README.md
+++ b/ruby/rails/petclinic/README.md
@@ -19,6 +19,19 @@ supported features.
 - This code is not tested in every AWS Region. For more information, see
   [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
 
+## TLS connection configuration
+
+This example uses direct TLS connections where supported, and verifies the server certificate is trusted. Verified SSL
+connections should be used where possible to ensure data security during transmission.
+
+* Driver versions following the release of PostgreSQL 17 support direct TLS connections, bypassing the traditional
+  PostgreSQL connection preamble
+* Direct TLS connections provide improved connection performance and enhanced security
+* Not all PostgreSQL drivers support direct TLS connections yet, or only in recent versions following PostgreSQL 17
+* Ensure your installed driver version supports direct TLS negotiation, or use a version that is at least as recent as
+  the one used in this sample
+* If your driver doesn't support direct TLS connections, you may need to use the traditional preamble connection instead
+
 ## Prerequisites
 
 * You must have an AWS account, and have your default credentials and AWS Region

--- a/ruby/rails/petclinic/config/database.yml
+++ b/ruby/rails/petclinic/config/database.yml
@@ -44,6 +44,7 @@ development:
   schema_search_path: myschema
   <% end %>
 
+  sslnegotiation: direct
   sslmode: verify-full
   # Provide the path to the root certificate. 
   # Amazon's root certs can be fetched from https://www.amazontrust.com/repository/


### PR DESCRIPTION
This PR modifies the `Rails` sample to set `sslnegotiation=direct` as per #150.

It does this conditionally based on the underlying `libpq` version, since the same `ruby-pg` version (used by Rails under the hood) can be used with multiple versions of `libpq`. I verified in the release notes [here](https://www.postgresql.org/docs/release/17.0/) that `sslnegotiation` has been available since the `17.0` release and was not added as a minor version bump.

We don't seem to need an explicit conditional for Rails, as it only passes the `sslnegotiation` parameter from `database.yml` when it is supported by `libpq`. I assume there is some kind of internal version checking going on. I tested the migrations with `libpq` 16 as well as 17. In Wireshark I saw it was doing direct TLS connections with 17, and gracefully falling back to the traditional connection approach with 16.

I added a section to the `README.md` file which describes more about the TLS configuration, and calls out that direct TLS connections are a new feature and may not be supported by all driver versions. This section was already reviewed in #160, and will be added to all samples which support direct TLS connections.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.