### PR TITLE
pgx: Configure connections using hooks rather than replacing pool

### DIFF
--- a/.github/workflows/go-pgx-integ-tests.yml
+++ b/.github/workflows/go-pgx-integ-tests.yml
@@ -53,6 +53,7 @@ jobs:
     - name: Build & Run
       working-directory: ./go/pgx
       env:
+        CLUSTER_USER: "admin"
         CLUSTER_ENDPOINT: ${{ secrets.GO_PGX_CLUSTER_ENDPOINT }}
         REGION: ${{ secrets.GO_PGX_CLUSTER_REGION }}
       run: |

--- a/go/pgx/README.md
+++ b/go/pgx/README.md
@@ -2,16 +2,18 @@
 
 ## Overview
 
-This code example demonstrates how to use the `pgx` driver with Amazon Aurora DSQL. The example shows you how to connect to an Aurora DSQL cluster and perform database operations using IAM authentication.
+This code example demonstrates how to use the `pgx` driver with Amazon Aurora DSQL. The example shows you how to connect
+to an Aurora DSQL cluster and perform database operations using IAM authentication.
 
-Aurora DSQL is a distributed SQL database service that provides high availability and scalability for your PostgreSQL-compatible applications. `pgx` is a pure Go driver and toolkit for PostgreSQL that offers robust features including automatic connection pool management and authentication token refresh.
-
+Aurora DSQL is a distributed SQL database service that provides high availability and scalability for your
+PostgreSQL-compatible applications. `pgx` is a pure Go driver and toolkit for PostgreSQL that offers robust features
+including automatic connection pool management and authentication token refresh.
 
 ## About the code example
 
 The example demonstrates a flexible connection approach using IAM authentication:
 
-- Implements automatic token refresh mechanism to maintain continuous database connectivity
+- Implements automatic token generation for new connections
 - Handles secure IAM-based authentication token generation
 - Provides connection pooling and management
 - Demonstrates best practices for Aurora DSQL connectivity in Go applications
@@ -42,16 +44,11 @@ connections should be used where possible to ensure data security during transmi
 
 The following environment variables can be used to configure the connection parameter in this example:
 
-- `CLUSTER_ENDPOINT`: Your Aurora cluster endpoint (required)
+- `CLUSTER_ENDPOINT`: Your Aurora DSQL cluster endpoint (required)
+- `CLUSTER_USER`: Database user (required)
 - `REGION`: AWS region where your cluster is located (required)
-- `CLUSTER_USER`: Database user (defaults to "admin")
-- `DB_HOST`: Database host (defaults to CLUSTER_ENDPOINT)
 - `DB_PORT`: Database port (defaults to 5432)
-- `DB_USER`: Database user (defaults to CLUSTER_USER)
 - `DB_NAME`: Database name (defaults to "postgres")
-- `DB_USE_IAM`: Whether to use IAM authentication (defaults to false)
-- `DB_REFRESH_TOKEN`: Whether to enable token refresh (defaults to true)
-- `TOKEN_REFRESH_INTERVAL`: Token refresh interval in seconds (defaults to 900 seconds / 15 minutes)
 
 ## Run the examples
 
@@ -61,20 +58,21 @@ The following environment variables can be used to configure the connection para
   configured as described in the
   [Globally configuring AWS SDKs and tools](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html)
   guide.
--You must have an Aurora DSQL cluster. For information about creating an Aurora DSQL cluster, see the
-      [Getting started with Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
-      guide.
+- You must have an Aurora DSQL cluster. For information about creating an Aurora DSQL cluster, see the
+  [Getting started with Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
+  guide.
 - If connecting as a non-admin user, ensure the user is linked to an IAM role and is granted access to the `myschema`
   schema. See the
   [Using database roles with IAM roles](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/using-database-and-iam-roles.html)
   guide.
-- Go version >= 1.21
+- Go version >= 1.24
 
 ### Setup test running environment
 
 Ensure you are authenticated with AWS credentials. No other setup is needed besides having Go installed.
 
 ### Environment Variables
+
 Set the following required environment variables:
 
 ```shell
@@ -90,30 +88,26 @@ export REGION="<your cluster region>"
 In a terminal run the following commands:
 
 ```sh
-# Use the account credentials dedicated for golang
+# Run the unit tests
 go env -w GOPROXY=direct
 go test
 
-# you can also run the example directly
-go build
+# Run the example directly
+go build -o example
 ./example
 ```
 
-## Token Refresh
+## Token Generation
 
-Token Refresh
-The implementation includes an automatic token refresh mechanism that:
-
-1. Creates a new token before the current one expires (default: every 15 minutes)
-
-1. Ensures continuous database connectivity
-
-1. Handles token generation and rotation securelye fresh connections with valid authentication tokens.
+The implementation includes an automatic token generation mechanism for new connections. This ensures continuous
+database connectivity for the pool. Lazily created connections will generate a new authentication token before
+connecting. Similarly, replacement connections for those exceeding the pool connection
+lifetime will generate their own fresh authentication token.
 
 ## Additional resources
 
 - [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
-- [AWS SDK for Go Documentation](https://docs.aws.amazon.com/sdk-for-go/)
+- [pgx Documentation](https://pkg.go.dev/github.com/jackc/pgx/v5)
 
 ---
 

--- a/go/pgx/example_test.go
+++ b/go/pgx/example_test.go
@@ -2,25 +2,189 @@ package main
 
 import (
 	"context"
-	"fmt"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
 	"os"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestExample(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
+func init() {
+	if os.Getenv("CLUSTER_ENDPOINT") == "" {
+		panic("environment variable CLUSTER_ENDPOINT not set")
 	}
 
+	if os.Getenv("REGION") == "" {
+		panic("environment variable REGION not set")
+	}
+}
+
+// cacheEnvVar returns a function that can be used to restore the original environment variable value
+func cacheEnvVar(t *testing.T, key string) func() {
+	original, exists := os.LookupEnv(key)
+
+	return func() {
+		if exists {
+			err := os.Setenv(key, original)
+			assert.NoError(t, err)
+		} else {
+			err := os.Unsetenv(key)
+			assert.NoError(t, err)
+		}
+	}
+}
+
+// setAndCacheEnvVar sets an environment variable and returns a function that can be used to restore the original value
+func setAndCacheEnvVar(t *testing.T, key string, value string) func() {
+	callback := cacheEnvVar(t, key)
+
+	err := os.Setenv(key, value)
+	assert.NoError(t, err)
+
+	return callback
+}
+
+// getConnectionID gets a unique identifier for a connection without using pg_backend_pid
+func getConnectionID(t *testing.T, ctx context.Context, pool *pgxpool.Pool) string {
+	var connID string
+	err := pool.QueryRow(ctx, "select sys.current_session_id();").Scan(&connID)
+	assert.NoError(t, err)
+
+	return connID
+}
+
+func assertPoolWorks(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	err := pool.Ping(ctx)
+	assert.NoError(t, err)
+}
+
+func assertPoolPanics(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	assert.Panics(t, func() {
+		err := pool.Ping(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}, "Expected pool ping to panic")
+}
+
+func TestGenerateDbConnectAuthToken(t *testing.T) {
+	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
+	assert.NotEmpty(t, clusterEndpoint, "cluster endpoint must not be empty")
+
+	region := os.Getenv("REGION")
+	assert.NotEmpty(t, region, "region must not be empty")
+
+	// Expiry doesn't matter since we don't intend to connect with it.
+	tokenExpiry := 1 * time.Second
+
+	// Test token generation
+	ctx := context.Background()
+	token, err := GenerateDbConnectAuthToken(ctx, clusterEndpoint, region, "admin", tokenExpiry)
+	assert.NoError(t, err)
+
+	assert.NotEmpty(t, token, "auth token must not be empty")
+}
+
+func TestNewPool(t *testing.T) {
+	ctx := context.Background()
+	pool, cancel, err := NewPool(ctx)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
+
+	assertPoolWorks(t, ctx, pool)
+}
+
+func TestTokenExpiryConfigurable(t *testing.T) {
+	resetVar := setAndCacheEnvVar(t, "TOKEN_EXPIRY_SECS", "-1")
+	defer resetVar()
+
+	ctx := context.Background()
+	pool, cancel, err := NewPool(ctx)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
+
+	assertPoolPanics(t, ctx, pool)
+}
+
+func TestGetEnv(t *testing.T) {
+	varName := "TEST_ENV_VAR"
+
+	resetVar := cacheEnvVar(t, varName)
+	defer resetVar()
+
+	// Test with environment variable set
+	err := os.Setenv(varName, "test_value")
+	assert.NoError(t, err)
+	result := getEnv(varName, "default_value")
+	assert.Equal(t, "test_value", result, "Should return the environment variable value when set")
+
+	// Test with environment variable not set
+	err = os.Unsetenv(varName)
+	assert.NoError(t, err)
+	result = getEnv(varName, "default_value")
+	assert.Equal(t, "default_value", result, "Should return the default value when environment variable is not set")
+}
+
+func TestGetEnvOrThrow(t *testing.T) {
+	varName := "TEST_ENV_VAR"
+
+	resetVar := cacheEnvVar(t, varName)
+	defer resetVar()
+
+	// Test with environment variable set
+	err := os.Setenv(varName, "test_value")
+	assert.NoError(t, err)
+
+	// Should not panic when environment variable is set
+	assert.NotPanics(t, func() {
+		result := getEnvOrThrow(varName)
+		assert.Equal(t, "test_value", result, "Should return the environment variable value when set")
+	})
+
+	// Test with environment variable not set
+	err = os.Unsetenv(varName)
+	assert.NoError(t, err)
+
+	// Should panic when environment variable is not set
+	assert.Panics(t, func() {
+		getEnvOrThrow(varName)
+	}, "Should panic when environment variable is not set")
+}
+
+func TestGetEnvInt(t *testing.T) {
+	varName := "TEST_ENV_INT"
+
+	resetVar := cacheEnvVar(t, varName)
+	defer resetVar()
+
+	// Test with valid integer environment variable
+	err := os.Setenv(varName, "123")
+	assert.NoError(t, err)
+	result := getEnvInt(varName, 456)
+	assert.Equal(t, 123, result, "Should return the integer value from environment variable")
+
+	// Test with invalid integer environment variable
+	err = os.Setenv(varName, "not_an_int")
+	assert.NoError(t, err)
+	result = getEnvInt(varName, 456)
+	assert.Equal(t, 456, result, "Should return the default value when environment variable is not a valid integer")
+
+	// Test with environment variable not set
+	err = os.Unsetenv(varName)
+	assert.NoError(t, err)
+	result = getEnvInt(varName, 456)
+	assert.Equal(t, 456, result, "Should return the default value when environment variable is not set")
+}
+
+func TestExample(t *testing.T) {
 	// Run the example
 	err := example()
 	if err != nil {
@@ -28,767 +192,240 @@ func TestExample(t *testing.T) {
 	}
 }
 
-func TestGenerateDbConnectAdminAuthToken(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
+func configureTokenExpiry(t *testing.T) (time.Duration, func()) {
+	tokenExpiry := 2 * time.Second
 
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
+	expirySeconds := int(tokenExpiry.Seconds())
+	expiryString := strconv.Itoa(expirySeconds)
+
+	resetVar := setAndCacheEnvVar(t, "TOKEN_EXPIRY_SECS", expiryString)
+
+	return tokenExpiry, resetVar
+}
+
+// waitForExpiry waits long enough for a time duration to expire
+func waitForExpiry(t *testing.T, expiry time.Duration) {
+	waitTime := 2 * expiry
+	t.Logf("Waiting for %v to exceed expiry time...", waitTime)
+	time.Sleep(waitTime)
+}
+
+func TestEstablishedConnectionUsableAfterTokenExpiry(t *testing.T) {
+	poolConfig := func(config *pgxpool.Config) {
+		config.MaxConns = 1
+		config.MinConns = 1
 	}
 
-	// Create context and DSQL client
+	tokenExpiry, resetVar := configureTokenExpiry(t)
+	defer resetVar()
+
 	ctx := context.Background()
+	pool, cancel, err := NewPool(ctx, poolConfig)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
 
-	// Test token generation
-	token, err := GenerateDbConnectAuthToken(ctx, clusterEndpoint, region, "admin")
-	if err != nil {
-		t.Errorf("Error generating auth token: %v\n", err)
-	}
+	// Initial test to verify connection works
+	assertPoolWorks(t, ctx, pool)
+	connIdBefore := getConnectionID(t, ctx, pool)
 
-	if token == "" {
-		t.Error("Generated token is empty")
-	}
+	waitForExpiry(t, tokenExpiry)
+
+	// Test that the existing connection still works after token would have expired
+	assertPoolWorks(t, ctx, pool)
+	connIdAfter := getConnectionID(t, ctx, pool)
+
+	assert.Equal(t, connIdBefore, connIdAfter, "Connection IDs should match")
 }
 
-func TestNewPool(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
+func TestLazyConnectionUsableAfterInitialInactivity(t *testing.T) {
+	poolConfig := func(config *pgxpool.Config) {
+		config.MaxConns = 1
+		config.MinConns = 0
 	}
 
-	// Create a new pool with token refresh
+	tokenExpiry, resetVar := configureTokenExpiry(t)
+	defer resetVar()
+
 	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
+	pool, cancel, err := NewPool(ctx, poolConfig)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
 
-	// Test connection
-	err = pool.Pool.Ping(ctx)
-	if err != nil {
-		t.Errorf("Error pinging database: %v\n", err)
-	}
+	waitForExpiry(t, tokenExpiry)
+
+	// Test that a new connection works after token would have expired
+	assertPoolWorks(t, ctx, pool)
 }
 
-// getConnectionID gets a unique identifier for a connection without using pg_backend_pid
-func getConnectionID(ctx context.Context, pool *pgxpool.Pool) (string, error) {
-	var connID string
-	err := pool.QueryRow(ctx, "select sys.current_session_id();").Scan(&connID)
-	if err != nil {
-		return "", err
+func TestConnectionUsableAfterPoolReset(t *testing.T) {
+	poolConfig := func(config *pgxpool.Config) {
+		config.MaxConns = 1
+		config.MinConns = 1
 	}
 
-	return connID, nil
-}
+	tokenExpiry, resetVar := configureTokenExpiry(t)
+	defer resetVar()
 
-func TestTokenRefresh(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
-
-	// Create a new pool with token refresh
 	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
+	pool, cancel, err := NewPool(ctx, poolConfig)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
 
-	// Get connection ID before refresh
-	connIDBefore, err := getConnectionID(ctx, pool.Pool)
-	if err != nil {
-		t.Errorf("Error getting connection ID before refresh: %v\n", err)
-		return
-	}
-	t.Logf("Connection ID before refresh: %s", connIDBefore)
+	assertPoolWorks(t, ctx, pool)
+	connIdBefore := getConnectionID(t, ctx, pool)
 
-	// Test manual token refresh
-	err = pool.refreshToken()
-	if err != nil {
-		t.Errorf("Error refreshing token: %v\n", err)
-		return
-	}
+	waitForExpiry(t, tokenExpiry)
+	pool.Reset()
 
-	// Test connection after refresh
-	err = pool.Pool.Ping(ctx)
-	if err != nil {
-		t.Errorf("Error pinging database after token refresh: %v\n", err)
-		return
-	}
+	// Test that a new connections works after the pool reset
+	assertPoolWorks(t, ctx, pool)
+	connIdAfter := getConnectionID(t, ctx, pool)
 
-	// Get connection ID after refresh
-	connIDAfter, err := getConnectionID(ctx, pool.Pool)
-	if err != nil {
-		t.Errorf("Error getting connection ID after refresh: %v\n", err)
-		return
-	}
-	t.Logf("Connection ID after refresh: %s", connIDAfter)
-
-	// Verify that the connections are different
-	if connIDBefore == connIDAfter {
-		t.Errorf("Connection IDs before and after refresh are the same: %s", connIDBefore)
-	} else {
-		t.Logf("Successfully verified that connections before and after refresh are different")
-	}
+	assert.NotEqual(t, connIdBefore, connIdAfter, "Connection IDs should not match")
 }
 
-func TestMultipleConnectionsRefresh(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
+func TestNewConnectionAfterPoolExpiry(t *testing.T) {
+	connectionExpiry := 2 * time.Second
 
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
+	poolConfig := func(config *pgxpool.Config) {
+		config.MaxConns = 1
+		config.MinConns = 1
+		config.MaxConnLifetime = connectionExpiry
 	}
 
-	// Create a new pool with token refresh
 	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
+	pool, cancel, err := NewPool(ctx, poolConfig)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
 
-	// Get multiple connection IDs before refresh
-	connIDsBefore := make(map[string]bool)
-	for i := 0; i < 3; i++ {
-		conn, err := pool.Pool.Acquire(ctx)
-		if err != nil {
-			t.Errorf("Error acquiring connection %d before refresh: %v\n", i, err)
-			return
-		}
+	assertPoolWorks(t, ctx, pool)
+	connIdBefore := getConnectionID(t, ctx, pool)
 
-		var connID string
-		err = conn.QueryRow(ctx, "select sys.current_session_id();").Scan(&connID)
-		if err != nil {
-			conn.Release()
-			t.Errorf("Error getting connection ID %d before refresh: %v\n", i, err)
-			return
-		}
+	waitForExpiry(t, connectionExpiry)
 
-		connIDsBefore[connID] = true
-		t.Logf("Connection ID %d before refresh: %s", i, connID)
-		conn.Release()
-	}
+	// Test that a new connections is established after the connection expiry period
+	assertPoolWorks(t, ctx, pool)
+	connIdAfter := getConnectionID(t, ctx, pool)
 
-	// Test manual token refresh
-	err = pool.refreshToken()
-	if err != nil {
-		t.Errorf("Error refreshing token: %v\n", err)
-		return
-	}
-
-	// Get multiple connection IDs after refresh
-	connIDsAfter := make(map[string]bool)
-	for i := 0; i < 3; i++ {
-		conn, err := pool.Pool.Acquire(ctx)
-		if err != nil {
-			t.Errorf("Error acquiring connection %d after refresh: %v\n", i, err)
-			return
-		}
-
-		var connID string
-		err = conn.QueryRow(ctx, "select sys.current_session_id();").Scan(&connID)
-		if err != nil {
-			conn.Release()
-			t.Errorf("Error getting connection ID %d after refresh: %v\n", i, err)
-			return
-		}
-
-		connIDsAfter[connID] = true
-		t.Logf("Connection ID %d after refresh: %s", i, connID)
-		conn.Release()
-	}
-
-	// Check if any connection IDs are the same before and after refresh
-	for beforeID := range connIDsBefore {
-		if connIDsAfter[beforeID] {
-			t.Errorf("Found same connection ID before and after refresh: %s", beforeID)
-			return
-		}
-	}
-
-	t.Logf("Successfully verified that all connections before and after refresh are different")
+	assert.NotEqual(t, connIdBefore, connIdAfter, "Connection IDs should not match")
 }
 
-func TestComprehensiveConnectionRefresh(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
+func TestConnectionConcurrencyAfterTokenExpiry(t *testing.T) {
+	numConnections := 20
 
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
+	poolConfig := func(config *pgxpool.Config) {
+		config.MaxConns = int32(numConnections)
+		config.MinConns = 1
 	}
 
-	// Create a new pool with token refresh
 	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
+	pool, cancel, err := NewPool(ctx, poolConfig)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
+
+	assertPoolWorks(t, ctx, pool)
+	initialConnId := getConnectionID(t, ctx, pool)
+	t.Logf("Initial connection ID: %s", initialConnId)
+
+	connIdCh := make(chan string, numConnections)
+	errCh := make(chan error, numConnections)
 
-	// Get the initial pool stats
-	initialStats := pool.Pool.Stat()
-	t.Logf("Initial pool stats: Total=%d, Idle=%d, InUse=%d",
-		initialStats.TotalConns(), initialStats.IdleConns(), initialStats.AcquiredConns())
-
-	// Create a map to store connection IDs before refresh
-	connIDsBefore := make(map[string]bool)
-
-	// Acquire all possible connections and get their IDs
-	maxConns := 5 // Use a reasonable number for testing
-	conns := make([]*pgxpool.Conn, 0, maxConns)
-
-	for i := 0; i < maxConns; i++ {
-		conn, err := pool.Pool.Acquire(ctx)
-		if err != nil {
-			t.Logf("Acquired %d connections before hitting limit", i)
-			break
-		}
-		conns = append(conns, conn)
-
-		var connID string
-		err = conn.QueryRow(ctx, "select sys.current_session_id();").Scan(&connID)
-		if err != nil {
-			t.Errorf("Error getting connection ID for conn %d: %v", i, err)
-			continue
-		}
-
-		connIDsBefore[connID] = true
-		t.Logf("Connection %d before refresh: ID=%s", i, connID)
-	}
-
-	// Release all connections back to the pool
-	for _, conn := range conns {
-		conn.Release()
-	}
-	conns = nil
-
-	// Get pool stats before refresh
-	beforeStats := pool.Pool.Stat()
-	t.Logf("Pool stats before refresh: Total=%d, Idle=%d, InUse=%d",
-		beforeStats.TotalConns(), beforeStats.IdleConns(), beforeStats.AcquiredConns())
-
-	// Perform token refresh
-	t.Log("Performing token refresh...")
-	err = pool.refreshToken()
-	if err != nil {
-		t.Errorf("Error refreshing token: %v", err)
-		return
-	}
-
-	// Get pool stats after refresh
-	afterStats := pool.Pool.Stat()
-	t.Logf("Pool stats after refresh: Total=%d, Idle=%d, InUse=%d",
-		afterStats.TotalConns(), afterStats.IdleConns(), afterStats.AcquiredConns())
-
-	// Create a map to store connection IDs after refresh
-	connIDsAfter := make(map[string]bool)
-
-	// Acquire connections from the refreshed pool
-	conns = make([]*pgxpool.Conn, 0, maxConns)
-	for i := 0; i < maxConns; i++ {
-		conn, err := pool.Pool.Acquire(ctx)
-		if err != nil {
-			t.Logf("Acquired %d connections before hitting limit", i)
-			break
-		}
-		conns = append(conns, conn)
-
-		var connID string
-		err = conn.QueryRow(ctx, "select sys.current_session_id();").Scan(&connID)
-		if err != nil {
-			t.Errorf("Error getting connection ID for conn %d: %v", i, err)
-			continue
-		}
-
-		connIDsAfter[connID] = true
-		t.Logf("Connection %d after refresh: ID=%s", i, connID)
-	}
-
-	// Release all connections
-	for _, conn := range conns {
-		conn.Release()
-	}
-
-	// Check if any connection IDs are the same before and after refresh
-	sameConnections := 0
-	for beforeID := range connIDsBefore {
-		if connIDsAfter[beforeID] {
-			sameConnections++
-			t.Logf("Found same connection ID before and after refresh: %s", beforeID)
-		}
-	}
-
-	if sameConnections > 0 {
-		t.Errorf("Found %d connections that were the same before and after refresh", sameConnections)
-	} else {
-		t.Logf("Successfully verified that all %d connections before and after refresh are different", len(connIDsBefore))
-	}
-}
-
-// TestGetEnv tests the getEnv utility function
-func TestGetEnv(t *testing.T) {
-	originalValue, originalExists := os.LookupEnv("TEST_ENV_VAR")
-
-	// Test with environment variable set
-	os.Setenv("TEST_ENV_VAR", "test_value")
-	result := getEnv("TEST_ENV_VAR", "default_value")
-	assert.Equal(t, "test_value", result, "Should return the environment variable value when set")
-
-	// Test with environment variable not set
-	os.Unsetenv("TEST_ENV_VAR")
-	result = getEnv("TEST_ENV_VAR", "default_value")
-	assert.Equal(t, "default_value", result, "Should return the default value when environment variable is not set")
-
-	// Restore original environment variable if it existed
-	if originalExists {
-		os.Setenv("TEST_ENV_VAR", originalValue)
-	} else {
-		os.Unsetenv("TEST_ENV_VAR")
-	}
-}
-
-// TestGetEnvInt tests the getEnvInt utility function
-func TestGetEnvInt(t *testing.T) {
-	originalValue, originalExists := os.LookupEnv("TEST_ENV_INT")
-
-	// Test with valid integer environment variable
-	os.Setenv("TEST_ENV_INT", "123")
-	result := getEnvInt("TEST_ENV_INT", 456)
-	assert.Equal(t, 123, result, "Should return the integer value from environment variable")
-
-	// Test with invalid integer environment variable
-	os.Setenv("TEST_ENV_INT", "not_an_int")
-	result = getEnvInt("TEST_ENV_INT", 456)
-	assert.Equal(t, 456, result, "Should return the default value when environment variable is not a valid integer")
-
-	// Test with environment variable not set
-	os.Unsetenv("TEST_ENV_INT")
-	result = getEnvInt("TEST_ENV_INT", 456)
-	assert.Equal(t, 456, result, "Should return the default value when environment variable is not set")
-
-	// Restore original environment variable if it existed
-	if originalExists {
-		os.Setenv("TEST_ENV_INT", originalValue)
-	} else {
-		os.Unsetenv("TEST_ENV_INT")
-	}
-}
-
-// TestGetConnectionID tests the GetConnectionID method of the Pool struct
-func TestGetConnectionID(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
-
-	// Create a new pool
-	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
-
-	// Test GetConnectionID method
-	connID, err := pool.GetConnectionID(ctx)
-	if err != nil {
-		t.Errorf("Error getting connection ID: %v\n", err)
-		return
-	}
-
-	// Verify that the connection ID is not empty
-	assert.NotEmpty(t, connID, "Connection ID should not be empty")
-	t.Logf("Connection ID: %s", connID)
-}
-
-// TestDemonstrateConnectionRefresh tests the DemonstrateConnectionRefresh method
-func TestDemonstrateConnectionRefresh(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
-
-	// Create a new pool
-	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
-
-	// Test DemonstrateConnectionRefresh method
-	err = pool.DemonstrateConnectionRefresh(ctx)
-	assert.NoError(t, err, "DemonstrateConnectionRefresh should not return an error")
-}
-
-// TestGetConnectionPool tests the getConnectionPool function
-func TestGetConnectionPool(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
-
-	// Test getConnectionPool function
-	ctx := context.Background()
-	pool, err := getConnectionPool(ctx, clusterEndpoint, region)
-	assert.NoError(t, err, "getConnectionPool should not return an error")
-	assert.NotNil(t, pool, "Connection pool should not be nil")
-
-	// Test that the pool is functional
-	err = pool.Ping(ctx)
-	assert.NoError(t, err, "Pool should be able to ping the database")
-
-	// Clean up
-	pool.Close()
-}
-
-// TestDatabaseOperations tests the database operations in the example function
-func TestDatabaseOperations(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
-
-	// Create a new pool
-	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
-
-	// Create owner table
-	_, err = pool.Pool.Exec(ctx, `
-                CREATE TABLE IF NOT EXISTS owner (
-                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                        name VARCHAR(255),
-                        city VARCHAR(255),
-                        telephone VARCHAR(255)
-                )
-        `)
-	assert.NoError(t, err, "Should be able to create owner table")
-
-	// Generate a unique test name to avoid conflicts with other test runs
-	testName := "Test User " + time.Now().Format("20060102150405")
-	testCity := "Test City"
-	testPhone := "555-123-4567"
-	testID := uuid.New()
-
-	// Test INSERT operation
-	_, err = pool.Pool.Exec(ctx,
-		`INSERT INTO owner (id, name, city, telephone) VALUES ($1, $2, $3, $4)`,
-		testID, testName, testCity, testPhone)
-	assert.NoError(t, err, "Should be able to insert a record")
-
-	// Test SELECT operation
-	var retrievedOwner Owner
-	err = pool.Pool.QueryRow(ctx,
-		`SELECT id, name, city, telephone FROM owner WHERE id = $1`,
-		testID).Scan(&retrievedOwner.Id, &retrievedOwner.Name, &retrievedOwner.City, &retrievedOwner.Telephone)
-	assert.NoError(t, err, "Should be able to select the inserted record")
-
-	// Verify the retrieved data
-	assert.Equal(t, testID.String(), retrievedOwner.Id, "Retrieved ID should match inserted ID")
-	assert.Equal(t, testName, retrievedOwner.Name, "Retrieved name should match inserted name")
-	assert.Equal(t, testCity, retrievedOwner.City, "Retrieved city should match inserted city")
-	assert.Equal(t, testPhone, retrievedOwner.Telephone, "Retrieved telephone should match inserted telephone")
-
-	// Test UPDATE operation
-	updatedCity := "Updated City"
-	_, err = pool.Pool.Exec(ctx,
-		`UPDATE owner SET city = $1 WHERE id = $2`,
-		updatedCity, testID)
-	assert.NoError(t, err, "Should be able to update a record")
-
-	// Verify the update
-	err = pool.Pool.QueryRow(ctx,
-		`SELECT city FROM owner WHERE id = $1`,
-		testID).Scan(&retrievedOwner.City)
-	assert.NoError(t, err, "Should be able to select the updated record")
-	assert.Equal(t, updatedCity, retrievedOwner.City, "Retrieved city should match updated city")
-
-	// Test DELETE operation
-	_, err = pool.Pool.Exec(ctx,
-		`DELETE FROM owner WHERE id = $1`,
-		testID)
-	assert.NoError(t, err, "Should be able to delete a record")
-
-	// Verify the deletion
-	var count int
-	err = pool.Pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM owner WHERE id = $1`,
-		testID).Scan(&count)
-	assert.NoError(t, err, "Should be able to count records")
-	assert.Equal(t, 0, count, "Record should be deleted")
-
-	// Clean up - drop the table if needed
-	// Uncomment if you want to drop the table after the test
-	// _, err = pool.Pool.Exec(ctx, `DROP TABLE IF EXISTS owner`)
-	// assert.NoError(t, err, "Should be able to drop the table")
-
-}
-
-// TestPeriodicTokenRefresh tests the automatic token refresh mechanism
-func TestPeriodicTokenRefresh(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
-
-	// Set a very short token refresh interval for testing (3 seconds)
-	os.Setenv("TOKEN_REFRESH_INTERVAL", "3")
-	defer os.Unsetenv("TOKEN_REFRESH_INTERVAL")
-
-	// Create a new pool with the short refresh interval
-	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
-
-	// Get connection ID before automatic refresh
-	connIDBefore, err := pool.GetConnectionID(ctx)
-	if err != nil {
-		t.Errorf("Error getting connection ID before refresh: %v\n", err)
-		return
-	}
-	t.Logf("Connection ID before automatic refresh: %s", connIDBefore)
-
-	// Wait for the automatic token refresh to occur (75% of 3 seconds = ~2.25 seconds)
-	// We'll wait 3 seconds to be safe
-	t.Log("Waiting for automatic token refresh...")
-	time.Sleep(3 * time.Second)
-
-	// Get connection ID after automatic refresh
-	connIDAfter, err := pool.GetConnectionID(ctx)
-	if err != nil {
-		t.Errorf("Error getting connection ID after refresh: %v\n", err)
-		return
-	}
-	t.Logf("Connection ID after automatic refresh: %s", connIDAfter)
-
-	// Verify that the connections are different
-	if connIDBefore == connIDAfter {
-		t.Errorf("Connection IDs before and after automatic refresh are the same: %s", connIDBefore)
-	} else {
-		t.Logf("Successfully verified that connections before and after automatic refresh are different")
-	}
-}
-
-// TestConcurrentConnections tests concurrent use of the connection pool
-func TestConcurrentConnections(t *testing.T) {
-	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
-
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
-
-	// Create a new pool
-	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
-
-	// Create owner table if it doesn't exist
-	_, err = pool.Pool.Exec(ctx, `
-                CREATE TABLE IF NOT EXISTS owner (
-                        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-                        name VARCHAR(255),
-                        city VARCHAR(255),
-                        telephone VARCHAR(255)
-                )
-        `)
-	assert.NoError(t, err, "Should be able to create owner table")
-
-	// Number of concurrent operations
-	numConcurrent := 10
 	var wg sync.WaitGroup
-	wg.Add(numConcurrent)
+	wg.Add(numConnections)
 
-	// Channel to collect errors
-	errorChan := make(chan error, numConcurrent)
-
-	// Run concurrent operations
-	for i := 0; i < numConcurrent; i++ {
-		go func(index int) {
+	// Start multiple goroutines that will each acquire a connection and hold it
+	for i := 0; i < numConnections; i++ {
+		go func(connIndex int) {
 			defer wg.Done()
 
-			// Generate unique data for this goroutine
-			testID := uuid.New()
-			testName := fmt.Sprintf("Concurrent User %d", index)
-			testCity := fmt.Sprintf("City %d", index)
-			testPhone := fmt.Sprintf("555-555-%04d", index)
-
-			// Insert a record
-			_, err := pool.Pool.Exec(ctx,
-				`INSERT INTO owner (id, name, city, telephone) VALUES ($1, $2, $3, $4)`,
-				testID, testName, testCity, testPhone)
+			// Run pg_sleep to hold the connection open to ensure concurrency.
+			var connID string
+			err := pool.QueryRow(ctx, "SELECT sys.current_session_id() FROM pg_sleep(5)").Scan(&connID)
 			if err != nil {
-				errorChan <- fmt.Errorf("goroutine %d insert error: %v", index, err)
-				return
+				errCh <- err
 			}
 
-			// Query the record
-			var retrievedOwner Owner
-			err = pool.Pool.QueryRow(ctx,
-				`SELECT id, name, city, telephone FROM owner WHERE id = $1`,
-				testID).Scan(&retrievedOwner.Id, &retrievedOwner.Name, &retrievedOwner.City, &retrievedOwner.Telephone)
-			if err != nil {
-				errorChan <- fmt.Errorf("goroutine %d query error: %v", index, err)
-				return
-			}
-
-			// Verify the data
-			if retrievedOwner.Name != testName || retrievedOwner.City != testCity || retrievedOwner.Telephone != testPhone {
-				errorChan <- fmt.Errorf("goroutine %d data mismatch: expected %s/%s/%s, got %s/%s/%s",
-					index, testName, testCity, testPhone,
-					retrievedOwner.Name, retrievedOwner.City, retrievedOwner.Telephone)
-				return
-			}
-
-			// Delete the record
-			_, err = pool.Pool.Exec(ctx,
-				`DELETE FROM owner WHERE id = $1`,
-				testID)
-			if err != nil {
-				errorChan <- fmt.Errorf("goroutine %d delete error: %v", index, err)
-				return
-			}
+			connIdCh <- connID
 		}(i)
 	}
 
-	// Wait for all goroutines to complete
+	// Close channels after all goroutines complete
 	wg.Wait()
-	close(errorChan)
+	close(errCh)
+	close(connIdCh)
 
-	// Check for errors
-	var errors []error
-	for err := range errorChan {
-		errors = append(errors, err)
+	// Fail the test if any of the goroutines failed
+	for err := range errCh {
+		t.Fatal(err)
 	}
 
-	// Report any errors
-	if len(errors) > 0 {
-		for _, err := range errors {
-			t.Errorf("%v", err)
-		}
-		t.Errorf("Concurrent operations had %d errors", len(errors))
-	} else {
-		t.Logf("Successfully completed %d concurrent operations", numConcurrent)
+	connectionIDs := make(map[string]bool)
+	for connID := range connIdCh {
+		connectionIDs[connID] = true
+		t.Logf("Connection ID: %s", connID)
 	}
+
+	assert.Equal(t, numConnections, len(connectionIDs), "Should have unique connection ID for each connection")
 }
 
-// TestPoolConfiguration tests that the connection pool is configured with the expected parameters
-func TestPoolConfiguration(t *testing.T) {
-	origClusterUser := os.Getenv("CLUSTER_USER")
-	origDbPort := os.Getenv("DB_PORT")
-	origDbName := os.Getenv("DB_NAME")
-	origTokenRefreshInterval := os.Getenv("TOKEN_REFRESH_INTERVAL")
-
-	// Set test environment variables
-	os.Setenv("CLUSTER_USER", "testuser")
-	os.Setenv("DB_PORT", "5433")
-	os.Setenv("DB_NAME", "testdb")
-	os.Setenv("TOKEN_REFRESH_INTERVAL", "600")
-
-	// Defer restoring original environment variables
-	defer func() {
-		if origClusterUser != "" {
-			os.Setenv("CLUSTER_USER", origClusterUser)
-		} else {
-			os.Unsetenv("CLUSTER_USER")
-		}
-
-		if origDbPort != "" {
-			os.Setenv("DB_PORT", origDbPort)
-		} else {
-			os.Unsetenv("DB_PORT")
-		}
-
-		if origDbName != "" {
-			os.Setenv("DB_NAME", origDbName)
-		} else {
-			os.Unsetenv("DB_NAME")
-		}
-
-		if origTokenRefreshInterval != "" {
-			os.Setenv("TOKEN_REFRESH_INTERVAL", origTokenRefreshInterval)
-		} else {
-			os.Unsetenv("TOKEN_REFRESH_INTERVAL")
-		}
-	}()
-
+// TestCustomPoolConfiguration tests that the connection pool is configured with the configured parameters
+func TestCustomPoolConfiguration(t *testing.T) {
 	clusterEndpoint := os.Getenv("CLUSTER_ENDPOINT")
-	region := os.Getenv("REGION")
+	assert.NotEmpty(t, clusterEndpoint, "cluster endpoint must not be empty")
 
-	if clusterEndpoint == "" || region == "" {
-		t.Skip("Skipping test because CLUSTER_ENDPOINT or REGION environment variables are not set")
-	}
+	clusterUser := os.Getenv("CLUSTER_USER")
+	assert.NotEmpty(t, clusterUser, "cluster user must not be empty")
+
+	resetPort := setAndCacheEnvVar(t, "DB_PORT", "5433")
+	defer resetPort()
+
+	resetDbName := setAndCacheEnvVar(t, "DB_NAME", "testdb")
+	defer resetDbName()
 
 	// Create a new pool with the custom configuration
 	ctx := context.Background()
-	pool, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool: %v\n", err)
-		return
-	}
-	defer pool.Close()
+	pool, cancel, err := NewPool(ctx)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
 
-	// Verify the configuration
-	assert.Equal(t, "testuser", pool.config.User, "User should match environment variable")
-	assert.Equal(t, "5433", pool.config.Port, "Port should match environment variable")
-	assert.Equal(t, "testdb", pool.config.Database, "Database should match environment variable")
-	assert.Equal(t, 600, pool.config.TokenRefreshInterval, "Token refresh interval should match environment variable")
-	assert.Equal(t, region, pool.config.Region, "Region should match input parameter")
-	assert.Equal(t, clusterEndpoint, pool.config.Host, "Host should match input parameter")
+	config := pool.Config().ConnConfig
 
-	// Test default values by unsetting environment variables
-	os.Unsetenv("CLUSTER_USER")
-	os.Unsetenv("DB_PORT")
-	os.Unsetenv("DB_NAME")
-	os.Unsetenv("TOKEN_REFRESH_INTERVAL")
+	assert.Equal(t, clusterEndpoint, config.Host)
+	assert.Equal(t, clusterUser, config.User)
+	assert.Equal(t, uint16(5433), config.Port)
+	assert.Equal(t, "testdb", config.Database)
+}
 
-	// Create another pool with default configuration
-	pool2, err := NewPool(ctx)
-	if err != nil {
-		t.Errorf("Error creating pool with default config: %v\n", err)
-		return
-	}
-	defer pool2.Close()
+// TestCustomPoolConfiguration tests that the connection pool defaults are as expected
+func TestDefaultPoolConfiguration(t *testing.T) {
+	ctx := context.Background()
+	pool, cancel, err := NewPool(ctx)
+	assert.NoError(t, err)
+	defer func() {
+		pool.Close()
+		cancel()
+	}()
 
-	// Verify default configuration
-	assert.Equal(t, "admin", pool2.config.User, "Default user should be 'admin'")
-	assert.Equal(t, "5432", pool2.config.Port, "Default port should be '5432'")
-	assert.Equal(t, "postgres", pool2.config.Database, "Default database should be 'postgres'")
-	assert.Equal(t, 900, pool2.config.TokenRefreshInterval, "Default token refresh interval should be 900 seconds")
+	config := pool.Config().ConnConfig
+
+	assert.Equal(t, uint16(5432), config.Port)
+	assert.Equal(t, "postgres", config.Database)
 }


### PR DESCRIPTION
This PR modifies the Go pgx driver sample to resolve a race-condition with the way the pool was being handled.

The pgx pool was previously wrapped in a custom construct which replaced the inner pool when the token needed to be refreshed. This had a few issues:

- Established connections do not need to be replaced until the `MaxConnLifetime` expires, even if the token which was used to authenticate them has already expired.
- The token refresh logic replaced the pool, which meant any parties with a reference to the old pool would experience errors after the pool was closed.
- A mutex was used to reconfigure the pool wrapper, which means any safe access to perform operations on the pool should also acquire the mutex. This mutex acquisition was missing in the sample, and this approach also wouldn't scale to allow for highly concurrent use of the pool.

To address these concerns, I've removed the custom pool wrapped and utilized the `BeforeConnect` pool hook to generate an authentication token for each new connection on the fly. Since generating a token does not need to make any network requests, this is very fast, and has negligible overhead compared to opening a DB connection. This appears to be the recommended approach in https://github.com/jackc/pgx/issues/676.

Since this approach is fundamentally incompatible with the previous approach, the diff in this PR is quite large. There was a significant reduction in the size/complexity of this sample as part of this change, so I would recommend primarily focusing on the "new" side of the diff. I also updated the tests which relied pretty heavily on the structure of the previous approach.

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.