### PR TITLE
Add SQLAlchemy sample for Aurora DSQL

### DIFF
--- a/python/sqlalchemy/README.md
+++ b/python/sqlalchemy/README.md
@@ -1,0 +1,153 @@
+# Aurora DSQL with SQLAlchemy
+
+## Overview
+
+This code example demonstrates how to use SQLAlchemy with Amazon Aurora DSQL. The example shows you how to connect to an Aurora DSQL cluster with SQLAlchemy using the Aurora DSQL Python Connector, define ORM models, and perform CRUD operations.
+
+Aurora DSQL is a distributed SQL database service that provides high availability and scalability for your PostgreSQL-compatible applications. SQLAlchemy is a popular Python SQL toolkit and ORM that provides a full suite of well-known enterprise-level persistence patterns.
+
+## About the code example
+
+This example uses the [Aurora DSQL Python Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/python/connector) which automatically handles IAM token generation for authentication.
+
+The example demonstrates a flexible connection approach that works for both admin and non-admin users:
+* When connecting as an **admin user**, the example uses the `public` schema and generates an admin authentication token.
+* When connecting as a **non-admin user**, the example uses a custom `myschema` schema and generates a standard authentication token.
+
+The code automatically detects the user type and adjusts its behavior accordingly.
+
+## ⚠️ Important
+* Running this code might result in charges to your AWS account.
+* We recommend that you grant your code least privilege. At most, grant only the minimum permissions required to perform the task. For more information, see [Grant least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege).
+* This code is not tested in every AWS Region. For more information, see [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+
+## Run the example
+
+### Prerequisites
+* You must have an AWS account, and have your default credentials and AWS Region configured as described in the [Globally configuring AWS SDKs and tools](https://docs.aws.amazon.com/credref/latest/refdocs/creds-config-files.html) guide.
+* [Python 3.10](https://www.python.org/) or later.
+* You must have an Aurora DSQL cluster. For information about creating an Aurora DSQL cluster, see the [Getting started with Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html) guide.
+* If connecting as a non-admin user, ensure the user is linked to an IAM role and is granted access to the `myschema` schema. See the [Using database roles with IAM roles](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/using-database-and-iam-roles.html) guide.
+
+### Set up environment for examples
+1. Create and activate a Python virtual environment:
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+2. Install the required packages:
+```
+pip install -r requirements.txt
+```
+
+### Run the code
+
+The example demonstrates the following operations:
+* Connecting to Aurora DSQL using SQLAlchemy with IAM authentication
+* Creating tables using SQLAlchemy's `Base.metadata.create_all()`
+* Defining ORM models with UUID primary keys and application-level relationships
+* Inserting and querying data with relationship loading (joinedload)
+
+The example is designed to work with both admin and non-admin users:
+* When run as an admin user, it uses the `public` schema
+* When run as a non-admin user, it uses the `myschema` schema
+
+**Note:** running the example will use actual resources in your AWS account and may incur charges.
+
+Set environment variables for your cluster details:
+```
+# e.g. "admin"
+export CLUSTER_USER="<your user>"
+
+# e.g. "foo0bar1baz2quux3quuux4.dsql.us-east-1.on.aws"
+export CLUSTER_ENDPOINT="<your endpoint>"
+```
+
+Run the example:
+```
+python -m src.example
+```
+
+Run the tests:
+```
+pytest
+```
+
+## Usage notes
+
+### Connecting to DSQL
+
+Aurora DSQL is PostgreSQL-compatible, so use the `postgresql+psycopg` dialect. The Aurora DSQL Python Connector handles IAM token generation automatically. Pass a connection creator to SQLAlchemy's `create_engine`.
+
+Aurora DSQL does not support `SAVEPOINT`, which SQLAlchemy's psycopg dialect uses during initialization. Set `isolation_level="AUTOCOMMIT"` and `autocommit=True` on the connection to avoid this:
+
+```python
+import aurora_dsql_psycopg as dsql
+from sqlalchemy import create_engine
+
+engine = create_engine(
+    "postgresql+psycopg://",
+    creator=lambda: dsql.connect(host=endpoint, user=user, autocommit=True),
+    isolation_level="AUTOCOMMIT",
+    pool_recycle=3300,  # Recycle before DSQL's 1-hour connection limit
+)
+```
+
+For non-admin users, set the search path using a connection event:
+
+```python
+from sqlalchemy import event
+
+@event.listens_for(engine, "connect")
+def set_search_path(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("SET search_path TO myschema")
+    cursor.close()
+```
+
+### Primary keys
+
+The SERIAL pseudo-type is not available in Aurora DSQL. Aurora DSQL supports [sequences and identity columns](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/sequences-identity-columns.html) (with `CACHE` specified), but UUIDs with `gen_random_uuid()` are the [recommended default](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/sequences-identity-columns-working-with.html) for primary keys:
+
+```python
+from uuid import UUID
+from sqlalchemy import Uuid, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+id: Mapped[UUID] = mapped_column(
+    Uuid, primary_key=True, server_default=text("gen_random_uuid()")
+)
+```
+
+### Relationships without foreign key constraints
+
+Aurora DSQL supports JOIN operations but does not enforce foreign key constraints. Do not use `ForeignKey()` in column definitions. Instead, define relationships using `relationship()` with explicit `primaryjoin` and `foreign()` annotations:
+
+```python
+from sqlalchemy.orm import relationship, foreign
+
+class Owner(Base):
+    __tablename__ = "owner"
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, server_default=text("gen_random_uuid()"))
+
+class Pet(Base):
+    __tablename__ = "pet"
+    owner_id: Mapped[Optional[UUID]] = mapped_column(Uuid, nullable=True)
+
+# Define after both classes exist
+Owner.pets = relationship(Pet, primaryjoin=Owner.id == foreign(Pet.owner_id), back_populates="owner")
+Pet.owner = relationship(Owner, primaryjoin=foreign(Pet.owner_id) == Owner.id, back_populates="pets")
+```
+
+The `foreign()` annotation tells SQLAlchemy which column is the "foreign" side of the join, replacing the role that `ForeignKey()` normally plays.
+
+## Additional resources
+* [Amazon Aurora DSQL Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/what-is-aurora-dsql.html)
+* [Sequences and identity columns in Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/sequences-identity-columns.html)
+* [Migrating from PostgreSQL to Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-migration-guide.html)
+* [Aurora DSQL Python Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/python/connector)
+* [SQLAlchemy Documentation](https://docs.sqlalchemy.org/)
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/python/sqlalchemy/gitignore
+++ b/python/sqlalchemy/gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/python/sqlalchemy/pyproject.toml
+++ b/python/sqlalchemy/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "sqlalchemy-dsql-example"
+version = "1.0.0"
+requires-python = ">=3.10"
+
+[tool.pytest.ini_options]
+testpaths = ["test"]
+pythonpath = ["."]

--- a/python/sqlalchemy/src/dsql_engine.py
+++ b/python/sqlalchemy/src/dsql_engine.py
@@ -1,0 +1,51 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+Aurora DSQL engine creation with automatic IAM authentication.
+
+Uses the Aurora DSQL Python Connector (psycopg3) for token generation.
+The engine runs in AUTOCOMMIT mode because Aurora DSQL does not support
+SAVEPOINT, which SQLAlchemy's psycopg dialect uses during initialization.
+"""
+
+import os
+
+import aurora_dsql_psycopg as dsql
+from sqlalchemy import create_engine, event
+from sqlalchemy.engine import Engine
+
+ADMIN = "admin"
+ADMIN_SCHEMA = "public"
+NON_ADMIN_SCHEMA = "myschema"
+
+
+def get_required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable {name}")
+    return value
+
+
+def create_dsql_engine() -> Engine:
+    host = get_required_env("CLUSTER_ENDPOINT")
+    user = get_required_env("CLUSTER_USER")
+    schema = ADMIN_SCHEMA if user == ADMIN else NON_ADMIN_SCHEMA
+
+    engine = create_engine(
+        "postgresql+psycopg://",
+        creator=lambda: dsql.connect(host=host, user=user, autocommit=True),
+        isolation_level="AUTOCOMMIT",
+        pool_pre_ping=True,
+        pool_size=5,
+        max_overflow=0,
+        pool_recycle=3300,  # Recycle before DSQL's 1-hour limit
+    )
+
+    @event.listens_for(engine, "connect")
+    def set_search_path(dbapi_connection, connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute(f"SET search_path TO {schema}")
+        cursor.close()
+
+    return engine

--- a/python/sqlalchemy/src/example.py
+++ b/python/sqlalchemy/src/example.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+CRUD operations demonstrating SQLAlchemy ORM with Aurora DSQL.
+"""
+
+from datetime import date
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session, joinedload
+
+from src.dsql_engine import create_dsql_engine
+from src.models import Base, Owner, Pet, Specialty, Vet, specialty_to_vet
+
+PET_1_BIRTH_DATE = date(2006, 10, 25)
+PET_2_BIRTH_DATE = date(2021, 7, 23)
+
+
+def run_example():
+    print("Starting SQLAlchemy DSQL Example...")
+    engine = create_dsql_engine()
+
+    print("Dropping existing tables (if any)...")
+    with engine.connect() as conn:
+        Base.metadata.drop_all(conn)
+        conn.commit()
+
+    print("Creating tables...")
+    with engine.connect() as conn:
+        Base.metadata.create_all(conn)
+        conn.commit()
+
+    with Session(engine) as session:
+        populate(session)
+        verify_pets(session)
+        verify_owners(session)
+        verify_vets(session)
+        cleanup(session)
+        print("Example completed successfully!")
+
+    print("Dropping tables...")
+    with engine.connect() as conn:
+        Base.metadata.drop_all(conn)
+        conn.commit()
+
+    engine.dispose()
+
+
+def populate(session: Session):
+    print("Creating owners...")
+    john = Owner(name="John Doe", city="New York")
+    mary = Owner(name="Mary Major", city="Anytown", telephone="555-555-0123")
+    session.add_all([john, mary])
+    session.flush()
+    print(f"Created owner: {john.name} (ID: {john.id})")
+    print(f"Created owner: {mary.name} (ID: {mary.id})")
+
+    print("Creating pets...")
+    pet1 = Pet(name="Pet1", birth_date=PET_1_BIRTH_DATE, owner_id=john.id)
+    pet2 = Pet(name="Pet2", birth_date=PET_2_BIRTH_DATE, owner_id=john.id)
+    session.add_all([pet1, pet2])
+    session.flush()
+    print(f"Created pet: {pet1.name} (Owner: {john.name})")
+    print(f"Created pet: {pet2.name} (Owner: {john.name})")
+
+    print("Creating veterinary specialties...")
+    exotic = Specialty(name="Exotic")
+    dogs = Specialty(name="Dogs")
+    cats = Specialty(name="Cats")
+    session.add_all([exotic, dogs, cats])
+    session.flush()
+    print("Created specialties: Exotic, Dogs, Cats")
+
+    print("Creating veterinarians...")
+    akua = Vet(name="Akua Mansa", specialties=[exotic])
+    carlos = Vet(name="Carlos Salazar", specialties=[cats, dogs])
+    session.add_all([akua, carlos])
+    session.commit()
+    print(f"Created vet: {akua.name} (Specialty: Exotic)")
+    print(f"Created vet: {carlos.name} (Specialties: Cats, Dogs)")
+
+
+def verify_pets(session: Session):
+    print("Querying pet information...")
+    pet1 = session.execute(
+        select(Pet).options(joinedload(Pet.owner)).where(Pet.name == "Pet1")
+    ).unique().scalar_one()
+    assert pet1.name == "Pet1"
+    assert pet1.birth_date == PET_1_BIRTH_DATE
+    assert pet1.owner.name == "John Doe"
+
+    pet2 = session.execute(
+        select(Pet).options(joinedload(Pet.owner)).where(Pet.name == "Pet2")
+    ).unique().scalar_one()
+    assert pet2.name == "Pet2"
+    assert pet2.birth_date == PET_2_BIRTH_DATE
+    assert pet2.owner.name == "John Doe"
+
+
+def verify_owners(session: Session):
+    print("Querying owner information...")
+    john = session.execute(
+        select(Owner).options(joinedload(Owner.pets)).where(Owner.name == "John Doe")
+    ).unique().scalar_one()
+    assert john.city == "New York"
+    assert john.telephone is None
+    assert len(john.pets) == 2
+
+    mary = session.execute(
+        select(Owner).options(joinedload(Owner.pets)).where(Owner.name == "Mary Major")
+    ).unique().scalar_one()
+    assert mary.city == "Anytown"
+    assert mary.telephone == "555-555-0123"
+    assert len(mary.pets) == 0
+
+
+def verify_vets(session: Session):
+    print("Querying veterinarians with specialties...")
+    akua = session.execute(
+        select(Vet).options(joinedload(Vet.specialties)).where(Vet.name == "Akua Mansa")
+    ).unique().scalar_one()
+    akua_specs = sorted([s.name for s in akua.specialties])
+    assert len(akua_specs) == 1
+    assert akua_specs[0] == "Exotic"
+
+    carlos = session.execute(
+        select(Vet)
+        .options(joinedload(Vet.specialties))
+        .where(Vet.name == "Carlos Salazar")
+    ).unique().scalar_one()
+    carlos_specs = sorted([s.name for s in carlos.specialties])
+    assert len(carlos_specs) == 2
+    assert carlos_specs[0] == "Cats"
+    assert carlos_specs[1] == "Dogs"
+
+
+def cleanup(session: Session):
+    print("Cleaning up...")
+    session.execute(delete(Pet))
+    session.execute(specialty_to_vet.delete())
+    session.execute(delete(Owner))
+    session.execute(delete(Specialty))
+    session.execute(delete(Vet))
+    session.commit()
+    print("Cleanup complete.")
+
+
+if __name__ == "__main__":
+    run_example()

--- a/python/sqlalchemy/src/example.py
+++ b/python/sqlalchemy/src/example.py
@@ -21,30 +21,34 @@ def run_example():
     print("Starting SQLAlchemy DSQL Example...")
     engine = create_dsql_engine()
 
-    print("Dropping existing tables (if any)...")
-    with engine.connect() as conn:
-        Base.metadata.drop_all(conn)
-        conn.commit()
+    try:
+        print("Dropping existing tables (if any)...")
+        with engine.connect() as conn:
+            Base.metadata.drop_all(conn)
+            conn.commit()
 
-    print("Creating tables...")
-    with engine.connect() as conn:
-        Base.metadata.create_all(conn)
-        conn.commit()
+        print("Creating tables...")
+        with engine.connect() as conn:
+            Base.metadata.create_all(conn)
+            conn.commit()
 
-    with Session(engine) as session:
-        populate(session)
-        verify_pets(session)
-        verify_owners(session)
-        verify_vets(session)
-        cleanup(session)
-        print("Example completed successfully!")
+        with Session(engine) as session:
+            populate(session)
+            verify_pets(session)
+            verify_owners(session)
+            verify_vets(session)
+            cleanup(session)
+            print("Example completed successfully!")
 
-    print("Dropping tables...")
-    with engine.connect() as conn:
-        Base.metadata.drop_all(conn)
-        conn.commit()
-
-    engine.dispose()
+        print("Dropping tables...")
+        with engine.connect() as conn:
+            Base.metadata.drop_all(conn)
+            conn.commit()
+    except Exception as e:
+        print(f"Error: {e}")
+        raise
+    finally:
+        engine.dispose()
 
 
 def populate(session: Session):

--- a/python/sqlalchemy/src/models.py
+++ b/python/sqlalchemy/src/models.py
@@ -4,9 +4,15 @@
 """
 SQLAlchemy ORM models for the veterinary domain.
 
-Aurora DSQL uses UUIDs as the recommended primary key type and does not
-enforce foreign key constraints. Relationships are managed at the ORM
-level using explicit primaryjoin with foreign() annotations.
+Aurora DSQL recommends UUIDs as the primary key type. Foreign key
+constraints are not supported, so ForeignKey() cannot be used in column
+definitions. Without ForeignKey(), SQLAlchemy cannot auto-detect join
+conditions between tables. To define relationships, we use
+relationship() with explicit primaryjoin and foreign() annotations.
+The foreign() annotation tells SQLAlchemy which column is the
+referencing side of the join, replacing the role ForeignKey() normally
+plays. See: https://docs.sqlalchemy.org/en/20/orm/join_conditions.html
+#creating-custom-foreign-conditions
 """
 
 from datetime import date

--- a/python/sqlalchemy/src/models.py
+++ b/python/sqlalchemy/src/models.py
@@ -1,0 +1,100 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+"""
+SQLAlchemy ORM models for the veterinary domain.
+
+Aurora DSQL uses UUIDs as the recommended primary key type and does not
+enforce foreign key constraints. Relationships are managed at the ORM
+level using explicit primaryjoin with foreign() annotations.
+"""
+
+from datetime import date
+from typing import List, Optional
+from uuid import UUID
+
+from sqlalchemy import Column, String, Table, Uuid, Date, text
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    mapped_column,
+    relationship,
+    foreign,
+)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+specialty_to_vet = Table(
+    "specialty_to_vet",
+    Base.metadata,
+    Column("specialty_name", String(80), primary_key=True),
+    Column("vet_id", Uuid, primary_key=True),
+)
+
+
+class Owner(Base):
+    __tablename__ = "owner"
+
+    id: Mapped[UUID] = mapped_column(
+        Uuid, primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    name: Mapped[str] = mapped_column(String(30))
+    city: Mapped[str] = mapped_column(String(80))
+    telephone: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
+
+
+class Pet(Base):
+    __tablename__ = "pet"
+
+    id: Mapped[UUID] = mapped_column(
+        Uuid, primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    name: Mapped[str] = mapped_column(String(30))
+    birth_date: Mapped[date] = mapped_column(Date)
+    owner_id: Mapped[Optional[UUID]] = mapped_column(Uuid, nullable=True)
+
+
+class Specialty(Base):
+    __tablename__ = "specialty"
+
+    name: Mapped[str] = mapped_column(String(80), primary_key=True)
+
+
+class Vet(Base):
+    __tablename__ = "vet"
+
+    id: Mapped[UUID] = mapped_column(
+        Uuid, primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    name: Mapped[str] = mapped_column(String(30))
+
+
+# Relationships defined after all classes exist, using foreign() since
+# Aurora DSQL does not enforce ForeignKey constraints.
+Owner.pets = relationship(
+    Pet,
+    primaryjoin=Owner.id == foreign(Pet.owner_id),
+    back_populates="owner",
+)
+Pet.owner = relationship(
+    Owner,
+    primaryjoin=foreign(Pet.owner_id) == Owner.id,
+    back_populates="pets",
+)
+Specialty.vets = relationship(
+    Vet,
+    secondary=specialty_to_vet,
+    primaryjoin=Specialty.name == foreign(specialty_to_vet.c.specialty_name),
+    secondaryjoin=Vet.id == foreign(specialty_to_vet.c.vet_id),
+    back_populates="specialties",
+)
+Vet.specialties = relationship(
+    Specialty,
+    secondary=specialty_to_vet,
+    primaryjoin=Vet.id == foreign(specialty_to_vet.c.vet_id),
+    secondaryjoin=Specialty.name == foreign(specialty_to_vet.c.specialty_name),
+    back_populates="vets",
+)

--- a/python/sqlalchemy/test/test_example.py
+++ b/python/sqlalchemy/test/test_example.py
@@ -1,0 +1,8 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+from src.example import run_example
+
+
+def test_run_example():
+    run_example()


### PR DESCRIPTION
Add SQLAlchemy sample for Aurora DSQL

This code example demonstrates how to use SQLAlchemy with Amazon Aurora DSQL. The example shows you how to connect to an Aurora DSQL cluster with SQLAlchemy using the Aurora DSQL Python Connector, define ORM models, and perform CRUD operations.