### PR TITLE
fix(go): Correct pool config and connector comments in recipe-sharing-api

### DIFF
--- a/go/recipe-sharing-api/internal/store/dsql.go
+++ b/go/recipe-sharing-api/internal/store/dsql.go
@@ -33,12 +33,12 @@ func NewDSQLStore(ctx context.Context, endpoint string) (*DSQLStore, error) {
 		return nil, fmt.Errorf("parse pool config: %w", err)
 	}
 	poolCfg.MaxConns = 5
-	poolCfg.MinConns = 1
+	poolCfg.MinConns = 0                       // Connections are created on demand; BeforeConnect generates a fresh IAM token.
 	poolCfg.MaxConnLifetime = 50 * time.Minute // Amazon Aurora DSQL timeout is 60 min.
 
 	// Create a connection pool using the Aurora DSQL connector.
-	// The connector handles IAM token generation, SSL/TLS configuration,
-	// and the prefer_simple_protocol setting automatically.
+	// The connector handles IAM token generation via BeforeConnect,
+	// TLS configuration (verify-full), and connection parameter defaults.
 	pool, err := dsql.NewPool(ctx, dsql.Config{
 		Host: endpoint,
 	}, poolCfg)


### PR DESCRIPTION
## Summary

- Set `MinConns` to 0 in the pgx pool config so connections are created on demand instead of maintaining an idle one. `BeforeConnect` generates a fresh IAM token per new connection, so pre-warming is unnecessary.
- Remove inaccurate comment claiming the connector sets `prefer_simple_protocol`. The connector handles IAM token generation via `BeforeConnect`, TLS with verify-full, and connection parameter defaults — it does not configure query execution mode.

This replaces #920, which accumulated unrelated sync commits and conflicts. Only the single authored change is cherry-picked here.

Credit: original commit authored by R. Steven Brown Jr. <rsbjr@amazon.com>.

## Test plan

- [ ] `go build ./...` in `go/recipe-sharing-api`
- [ ] Recipe-sharing-api integ tests run green against a DSQL cluster

By submitting this pull request, I confirm that this contribution is made under the terms of the MIT-0 license.