### PR TITLE
fix(deno/booking-api): enforce UUID v4 in BOOKING_ID_REGEX

### DIFF
--- a/deno/booking-api/postgres-js/handlers.ts
+++ b/deno/booking-api/postgres-js/handlers.ts
@@ -34,11 +34,14 @@ import type { Sql } from "./db.ts";
 const MAX_JSON_BODY_BYTES = 16 * 1024;
 
 /**
- * Strict UUID v4 (RFC 4122) path regex for booking IDs. Matching upstream
- * returns 404 for obviously malformed IDs without reaching the DB layer.
+ * Strict UUID v4 (RFC 4122) path regex for booking IDs. Enforces the v4
+ * version nibble (third group starts with `4`) and variant nibble (fourth
+ * group starts with `8`, `9`, `a`, or `b`). Aurora DSQL's
+ * `gen_random_uuid()` emits v4, so valid booking IDs always match; matching
+ * upstream returns 404 for malformed IDs without reaching the DB layer.
  */
 const BOOKING_ID_REGEX =
-  /^\/bookings\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  /^\/bookings\/[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 // ---------------------------------------------------------------------------
 // Types

--- a/deno/booking-api/postgres-js/router.property.test.ts
+++ b/deno/booking-api/postgres-js/router.property.test.ts
@@ -49,9 +49,11 @@ const VALID_ENDPOINTS = [
 const ALL_METHODS = ["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"];
 
 /**
- * Generates a valid UUID-like booking ID for parameterized routes.
+ * Generates a valid UUID v4 booking ID for parameterized routes. Constrained
+ * to v4 because `handlers.ts` BOOKING_ID_REGEX only accepts v4 (matching
+ * what Aurora DSQL's `gen_random_uuid()` emits).
  */
-const bookingIdArb = fc.uuid();
+const bookingIdArb = fc.uuid({ version: 4 });
 
 /**
  * Generates a random path that does NOT match any booking endpoint.
@@ -158,6 +160,41 @@ Deno.test("property: wrong method on valid path returns 404", async () => {
       },
     ),
     { numRuns: 20 },
+  );
+});
+
+Deno.test("property: non-v4 UUID shapes on /bookings/:id return 404", async () => {
+  // The router's BOOKING_ID_REGEX enforces UUID v4 (third group starts with
+  // `4`, fourth with `[89ab]`). Aurora DSQL's gen_random_uuid() always emits
+  // v4, so anything else is malformed input and is rejected upstream without
+  // touching the DB. This property covers v1/v3/v5 and the NIL UUID.
+  const nonV4UuidArb = fc.oneof(
+    fc.uuid({ version: 1 }),
+    fc.uuid({ version: 3 }),
+    fc.uuid({ version: 5 }),
+    fc.constant("00000000-0000-0000-0000-000000000000"),
+  );
+
+  await fc.assert(
+    fc.asyncProperty(
+      fc.constantFrom("GET", "PUT", "DELETE"),
+      nonV4UuidArb,
+      async (method, id) => {
+        const opts: RequestInit = { method };
+        if (method === "PUT") {
+          opts.body = JSON.stringify({ booked_by: "test" });
+          opts.headers = { "Content-Type": "application/json" };
+        }
+
+        const req = new Request(`http://localhost:8000/bookings/${id}`, opts);
+        const res = await handleRequest(req, CTX);
+        assertEquals(res.status, 404);
+
+        const body = await res.json();
+        assertEquals(body.error, "Not Found");
+      },
+    ),
+    { numRuns: 50 },
   );
 });
 

--- a/deno/booking-api/postgres-js/validation.property.test.ts
+++ b/deno/booking-api/postgres-js/validation.property.test.ts
@@ -83,9 +83,11 @@ Deno.test("property: POST /bookings rejects malformed JSON with 400", async () =
 });
 
 Deno.test("property: PUT /bookings/:id rejects malformed JSON with 400", async () => {
-  // Use a well-formed UUID so the router dispatches to updateBooking;
-  // the body parser then rejects malformed JSON with HTTP 400.
-  const validUuid = "00000000-0000-0000-0000-000000000000";
+  // Use a well-formed UUID v4 so the router dispatches to updateBooking;
+  // the body parser then rejects malformed JSON with HTTP 400. The third
+  // group starts with `4` (version) and the fourth with `8` (variant) to
+  // satisfy BOOKING_ID_REGEX in handlers.ts.
+  const validUuid = "00000000-0000-4000-8000-000000000000";
   await fc.assert(
     fc.asyncProperty(nonJsonStringArb, async (badBody) => {
       const req = new Request(


### PR DESCRIPTION
## What

Tightens BOOKING_ID_REGEX in handlers.ts to actually enforce UUID v4 (RFC 4122):

- Third group must start with `4` (version nibble)
- Fourth group must start with `8`, `9`, `a`, or `b` (variant nibble)

The regex previously matched any UUID shape despite the JSDoc labelling it "Strict UUID v4." Aurora DSQL's gen_random_uuid() only ever emits v4, so non-v4 UUIDs are always invalid input.

## Why

Closes the gap between the regex's documented intent and its actual behavior. Malformed-but-UUID-shaped IDs (v1 / v3 / v5 / NIL) are now rejected at the router with a plain `Not Found` before any DB round-trip, instead of passing through to the query layer.

## Changes

- handlers.ts: tighten the regex + expand the JSDoc.
- router.property.test.ts: constrain bookingIdArb to fc.uuid({ version: 4 }) so fast-check can't flake by generating v1/v3/v5.
- router.property.test.ts: add a new property asserting that v1/v3/v5 + NIL UUID shapes return 404 on /bookings/:id routes.
- validation.property.test.ts: replace the NIL UUID placeholder with a valid v4 so the router keeps dispatching to updateBooking.

## Testing

All verified against live cluster 2vtxqbhz3yi36bnswm22kat3cm (us-east-1):

- deno check: 13/13 TS files clean
- Property tests: **19/19 pass** (18 existing + 1 new non-v4 rejection test)
- Integration tests: **9/9 pass**
- OCC-race tests: **4/4 pass**
- Smoke tests: **15/15 pass**
- Manual curl verification: v4 UUID routes through to DB (`Booking not found`); non-v4 / NIL return router-level 404 (`Not Found`)