### PR TITLE
fix(spring-boot): use ConcurrencyFailureException for OCC retry

### DIFF
--- a/java/spring_boot/README.md
+++ b/java/spring_boot/README.md
@@ -107,7 +107,7 @@ Aurora DSQL uses optimistic concurrency control instead of traditional locking. 
 
 ```java
 @Retryable(
-    retryFor = OptimisticLockingFailureException.class,
+    retryFor = ConcurrencyFailureException.class,
     maxAttempts = 4,
     backoff = @Backoff(
         delay = 100,
@@ -125,7 +125,7 @@ public void updateStock(UUID productId, int quantity) {
 
 The `@Retryable` annotation automatically retries the operation when a concurrency conflict occurs:
 
-- **Conflict detection** – Spring translates the `40001` SQL state to `OptimisticLockingFailureException`
+- **Conflict detection** – When using Hibernate/JPA, Spring translates the `40001` SQL state to `CannotAcquireLockException` (a subclass of `ConcurrencyFailureException`). We retry on `ConcurrencyFailureException` to catch all concurrency-related exceptions regardless of the persistence layer used.
 - **Automatic retry** – If a conflict occurs, the method retries up to 4 times
 - **Exponential backoff** – Wait times increase exponentially (100ms → 200ms → 400ms → 800ms)
 - **Jitter** – Random delays prevent multiple retries from colliding again (known as the 'thundering herd' problem)

--- a/java/spring_boot/src/main/java/com/example/dsql/service/ProductService.java
+++ b/java/spring_boot/src/main/java/com/example/dsql/service/ProductService.java
@@ -2,7 +2,7 @@ package com.example.dsql.service;
 
 import com.example.dsql.model.Product;
 import com.example.dsql.repository.ProductRepository;
-import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.ConcurrencyFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
@@ -53,7 +53,7 @@ public class ProductService {
     }
 
     @Retryable(
-        retryFor = OptimisticLockingFailureException.class,
+        retryFor = ConcurrencyFailureException.class,
         maxAttempts = 4,
         backoff = @Backoff(delay = 100, multiplier = 2, random = true)
     )


### PR DESCRIPTION
## Summary

Fixes the Spring Boot sample's OCC retry logic to use `ConcurrencyFailureException` instead of `OptimisticLockingFailureException`.

## Problem

When using Hibernate/JPA, Spring's exception translation maps DSQL's `40001` SQLSTATE (OCC conflict) through this path:

```
DSQL returns SQLState 40001
  → Hibernate: LockAcquisitionException
    → Spring: CannotAcquireLockException
      → extends: PessimisticLockingFailureException
```

`PessimisticLockingFailureException` and `OptimisticLockingFailureException` are **siblings** under `ConcurrencyFailureException`, so `@Retryable(retryFor = OptimisticLockingFailureException.class)` never catches the actual exception.

## Fix

Use `ConcurrencyFailureException.class` (the common parent) which catches both the Hibernate/JPA path and the plain JDBC path.

## Changes

- `ProductService.java`: Changed import and `@Retryable` annotation
- `README.md`: Updated code example and corrected the explanation

## Testing

Verified that `ConcurrencyFailureException.class` catches OCC conflicts correctly (confirmed by dbblaner in V2203634665).

## Related

- Ticket: V2203634665