### PR TITLE
feat: add Amazon Aurora DSQL auth and session management sample

### DIFF
--- a/sample-amazon-aurora-dsql-auth-session-mgmt/.gitignore
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/.gitignore
@@ -1,0 +1,36 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Environment files
+.env
+.env.local
+.env.*.local
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Blog assets
+blog/
+
+# Placeholder files
+.gitkeep
+
+# Editor / OS
+.DS_Store
+.vscode/
+.idea/
+*.swp
+
+# Test coverage
+coverage/
+.nyc_output/
+
+# TypeScript
+*.tsbuildinfo

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
@@ -1,12 +1,12 @@
 # User Authentication Service with Session Management on Aurora DSQL
 
-A complete user authentication service with session management built on Amazon Aurora DSQL. Demonstrates DSQL-specific patterns including strong consistency, IAM authentication, OCC retry, and application-level referential integrity.
+A user authentication service with session management built on Amazon Aurora DSQL. Demonstrates DSQL-specific patterns including strong consistency, IAM authentication, OCC retry, and application-level referential integrity.
 
 ## Tech Stack
 
 - Node.js 20+ / TypeScript
 - Express.js
-- Amazon Aurora DSQL (via @aws/aurora-dsql-node-postgres-connector)
+- Amazon Aurora DSQL (via `@aws/aurora-dsql-node-postgres-connector`)
 - Vitest for testing
 
 ## Prerequisites
@@ -54,12 +54,12 @@ npm test
 # 1. Register
 curl -s -X POST http://localhost:3000/api/auth/register \
   -H "Content-Type: application/json" \
-  -d '{"email": "alice@test.com", "password": "secureP@ss1"}' | jq
+  -d '{"email": "alice@example.com", "password": "secureP@ss1"}' | jq
 
 # 2. Login
 curl -s -X POST http://localhost:3000/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email": "alice@test.com", "password": "secureP@ss1"}' | jq
+  -d '{"email": "alice@example.com", "password": "secureP@ss1"}' | jq
 
 # 3. Get profile (use token from login)
 curl -s http://localhost:3000/api/auth/me \
@@ -85,17 +85,17 @@ curl -s http://localhost:3000/api/auth/me \
 # Duplicate registration (expect 409)
 curl -s -X POST http://localhost:3000/api/auth/register \
   -H "Content-Type: application/json" \
-  -d '{"email": "alice@test.com", "password": "secureP@ss1"}' | jq
+  -d '{"email": "alice@example.com", "password": "secureP@ss1"}' | jq
 
 # Wrong password (expect 401, generic message)
 curl -s -X POST http://localhost:3000/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email": "alice@test.com", "password": "wrongpassword"}' | jq
+  -d '{"email": "alice@example.com", "password": "wrongpassword"}' | jq
 
-# Non-existent email (expect same 401 message - user enumeration prevention)
+# Non-existent email (expect same 401 message — user enumeration prevention)
 curl -s -X POST http://localhost:3000/api/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"email": "nobody@test.com", "password": "secureP@ss1"}' | jq
+  -d '{"email": "nobody@example.com", "password": "secureP@ss1"}' | jq
 
 # Invalid email format (expect 400)
 curl -s -X POST http://localhost:3000/api/auth/register \
@@ -105,7 +105,7 @@ curl -s -X POST http://localhost:3000/api/auth/register \
 # Short password (expect 400)
 curl -s -X POST http://localhost:3000/api/auth/register \
   -H "Content-Type: application/json" \
-  -d '{"email": "new@test.com", "password": "short"}' | jq
+  -d '{"email": "new@example.com", "password": "short"}' | jq
 
 # Missing fields (expect 400)
 curl -s -X POST http://localhost:3000/api/auth/register \
@@ -136,13 +136,31 @@ SELECT id, user_id, created_at, expires_at, revoked_at FROM sessions;
 ## DSQL-Specific Patterns
 
 - No foreign keys: referential integrity enforced in application code
-- No JSON/JSONB: use TEXT with app-layer serialization
-- CREATE INDEX ASYNC (not CREATE INDEX)
+- No JSONB: `client_metadata` is `TEXT` with app-layer JSON serialization
+- `CREATE INDEX ASYNC` (not `CREATE INDEX`)
 - OCC retry with exponential backoff (SQLSTATE 40001)
 - IAM-based database authentication (no static passwords)
-- UUIDs generated app-side (no sequences)
+- UUIDs generated app-side
 - 1 DDL per transaction
 - 3,000 row limit per DML transaction
+
+## Operational Notes
+
+### Async indexes are not immediately VALID
+
+`migrate.ts` uses `CREATE INDEX ASYNC`, which returns immediately while the index is built in the background. The first reads against `sessions.user_id` after a fresh migration will fall back to a full table scan until the index reaches `VALID` state. This is fine for an empty or small `sessions` table, but on a populated cluster you should wait for the index to finish building before relying on it for performance. See the [Aurora DSQL supported SQL features](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-features.html) page for guidance on monitoring async index status.
+
+The `sessions.token_hash` column is intentionally NOT given an explicit `CREATE INDEX` — the `UNIQUE` constraint on the column already creates a backing unique index, so adding a second one would just waste write IOPS.
+
+### Production hardening checklist
+
+This sample focuses on demonstrating Aurora DSQL patterns. Before running in production, add the following layers, none of which are DSQL-specific:
+
+- **Rate limiting.** This sample does not include `express-rate-limit` or any throttling. At minimum, add per-IP rate limits to `/api/auth/register` and `/api/auth/login` to slow brute-force credential stuffing.
+- **Trusted proxy / X-Forwarded-For handling.** `req.ip` is recorded in `client_metadata` for session listing. Behind a load balancer, this is the LB IP unless you configure `app.set('trust proxy', ...)` with the correct hop count. Configure it explicitly — never set `trust proxy: true` on a publicly exposed app, since that lets clients spoof `X-Forwarded-For`.
+- **bcrypt cost factor.** `passwordHasher.ts` uses cost 10 (~80–100 ms per verify on a typical CPU), suitable for a proof-of-concept. Increase to 12 or higher in production after benchmarking your target hardware.
+- **Logging and observability.** Replace the `console.warn` / `console.error` calls in `retryWithBackoff.ts` with a structured logger of your choice and forward to CloudWatch / your aggregator.
+- **Token storage on the client.** This sample returns the session token in JSON. In a browser app you'll typically want an HTTP-only, Secure cookie instead.
 
 ## Cleanup
 

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
@@ -1,0 +1,149 @@
+# User Authentication Service with Session Management on Aurora DSQL
+
+A complete user authentication service with session management built on Amazon Aurora DSQL. Demonstrates DSQL-specific patterns including strong consistency, IAM authentication, OCC retry, and application-level referential integrity.
+
+## Tech Stack
+
+- Node.js 20+ / TypeScript
+- Express.js
+- Amazon Aurora DSQL (via @aws/aurora-dsql-node-postgres-connector)
+- Vitest for testing
+
+## Prerequisites
+
+- AWS account with `AmazonAuroraDSQLConsoleFullAccess` policy
+- Node.js 20+ and npm
+- AWS CLI configured with valid credentials
+- An Aurora DSQL cluster (single-Region)
+
+## Setup
+
+1. Create a DSQL cluster at https://console.aws.amazon.com/dsql
+2. Wait for status to show Active
+3. Copy the cluster endpoint
+
+```bash
+npm install
+export DSQL_ENDPOINT="your-cluster-id.dsql.us-east-1.on.aws"
+npm run build
+npm start
+```
+
+## Running Tests (no DSQL cluster needed)
+
+```bash
+npm test
+```
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | /api/auth/register | Register a new user |
+| POST | /api/auth/login | Authenticate and receive a session token |
+| GET | /api/auth/me | Retrieve the authenticated user's profile |
+| GET | /api/sessions | List all active sessions |
+| DELETE | /api/sessions/:sessionId | Revoke a specific session |
+| DELETE | /api/sessions | Revoke all sessions (optionally exclude current) |
+
+## Testing the API
+
+### Happy path
+
+```bash
+# 1. Register
+curl -s -X POST http://localhost:3000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email": "alice@test.com", "password": "secureP@ss1"}' | jq
+
+# 2. Login
+curl -s -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "alice@test.com", "password": "secureP@ss1"}' | jq
+
+# 3. Get profile (use token from login)
+curl -s http://localhost:3000/api/auth/me \
+  -H "Authorization: Bearer <token>" | jq
+
+# 4. List sessions
+curl -s http://localhost:3000/api/sessions \
+  -H "Authorization: Bearer <token>" | jq
+
+# 5. Revoke a session (use session ID from list)
+curl -s -X DELETE http://localhost:3000/api/sessions/<session-id> \
+  -H "Authorization: Bearer <token>" | jq
+
+# 6. Verify revoked token is rejected (strong consistency)
+curl -s http://localhost:3000/api/auth/me \
+  -H "Authorization: Bearer <token>" | jq
+# Expected: 401 Invalid session
+```
+
+### Negative tests
+
+```bash
+# Duplicate registration (expect 409)
+curl -s -X POST http://localhost:3000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email": "alice@test.com", "password": "secureP@ss1"}' | jq
+
+# Wrong password (expect 401, generic message)
+curl -s -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "alice@test.com", "password": "wrongpassword"}' | jq
+
+# Non-existent email (expect same 401 message - user enumeration prevention)
+curl -s -X POST http://localhost:3000/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email": "nobody@test.com", "password": "secureP@ss1"}' | jq
+
+# Invalid email format (expect 400)
+curl -s -X POST http://localhost:3000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email": "not-an-email", "password": "secureP@ss1"}' | jq
+
+# Short password (expect 400)
+curl -s -X POST http://localhost:3000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{"email": "new@test.com", "password": "short"}' | jq
+
+# Missing fields (expect 400)
+curl -s -X POST http://localhost:3000/api/auth/register \
+  -H "Content-Type: application/json" \
+  -d '{}' | jq
+
+# Invalid token (expect 401)
+curl -s http://localhost:3000/api/auth/me \
+  -H "Authorization: Bearer fake-token-12345" | jq
+
+# No auth header (expect 401)
+curl -s http://localhost:3000/api/auth/me | jq
+
+# Revoke all sessions except current
+curl -s -X DELETE "http://localhost:3000/api/sessions?excludeCurrent=true" \
+  -H "Authorization: Bearer <token>" | jq
+```
+
+### Console verification
+
+In the DSQL Query Editor:
+
+```sql
+SELECT id, email, created_at FROM users;
+SELECT id, user_id, created_at, expires_at, revoked_at FROM sessions;
+```
+
+## DSQL-Specific Patterns
+
+- No foreign keys: referential integrity enforced in application code
+- No JSON/JSONB: use TEXT with app-layer serialization
+- CREATE INDEX ASYNC (not CREATE INDEX)
+- OCC retry with exponential backoff (SQLSTATE 40001)
+- IAM-based database authentication (no static passwords)
+- UUIDs generated app-side (no sequences)
+- 1 DDL per transaction
+- 3,000 row limit per DML transaction
+
+## Cleanup
+
+Delete the DSQL cluster when done to avoid charges.

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/package-lock.json
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/package-lock.json
@@ -1,0 +1,3324 @@
+{
+  "name": "auth-session-management-dsql",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "auth-session-management-dsql",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@aws-sdk/credential-providers": "^3.1037.0",
+        "@aws-sdk/dsql-signer": "^3.1037.0",
+        "@aws/aurora-dsql-node-postgres-connector": "^0.1.8",
+        "bcryptjs": "^3.0.3",
+        "express": "^5.2.1",
+        "pg": "^8.20.0"
+      },
+      "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
+        "@types/express": "^5.0.6",
+        "@types/pg": "^8.20.0",
+        "@types/supertest": "^7.2.0",
+        "supertest": "^7.2.2",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.1059.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.1059.0.tgz",
+      "integrity": "sha512-HW3Oq2rL65tbuqkQzoRrjfF3jauRfra056Xv0K2YtBWt+LaeLrr95D8SlRmgGzXZHwy38FO/w0N1EKjsTYmDKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/credential-provider-node": "^3.972.49",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.16.tgz",
+      "integrity": "sha512-WXPvTfG7J2H4Ae6ewhd0285UC+8+9p/pKoibXXQlbXSqHexFLGM0oXHTwDfQEPmrNnvuWPpVjgoAUfW+cUFbXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@aws-sdk/xml-builder": "^3.972.27",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.972.39.tgz",
+      "integrity": "sha512-fp7hiew245BbBiaDGjLDaMXqxbOWnqzuhczWrJq/6/3gDNHtZvkorxHQXYpHYiddetR8sBWe3S49HfZ2BQbYSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.42.tgz",
+      "integrity": "sha512-0+MCOYqeHyADFdeVr5/e1G8JJoWm7/szZAiKssqJS84E9+tO07509YNyQRJ5a7x5wO9YFAV324syrwm6yIcs5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.44.tgz",
+      "integrity": "sha512-auuhqlnv4PUdfqcdHLKGTdoCceXOuby6WNeCMoxtZmQGWNCibbz95/lSYzNWq9cExN17UlRFqo1nvTcC+zHfEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.47.tgz",
+      "integrity": "sha512-G+8JuG0CfLcC2IQXFVqMR1+KDF1rksebr+YL6+HHYbNjs/hiwX53ye45sU3pJKljpS2uIXqOrOsicHIv02vWrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/credential-provider-env": "^3.972.42",
+        "@aws-sdk/credential-provider-http": "^3.972.44",
+        "@aws-sdk/credential-provider-login": "^3.972.46",
+        "@aws-sdk/credential-provider-process": "^3.972.42",
+        "@aws-sdk/credential-provider-sso": "^3.972.46",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.46",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.46.tgz",
+      "integrity": "sha512-+H6h2/1Q+iIJ4w+FPCKM//xwy4C9yADknDTR68+K3PbOtB/uLup3zIH8PUKn6QwnttME4VM4ftSTnbvoDf5wXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.49.tgz",
+      "integrity": "sha512-hlyoc+2352BhC+HF91t9avIDJu1+EvQGGltxFB8ADCpAHGYNNLEQAZJIPzw3O/bRiiDSE2B8pdj/fFCXlDTEDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.42",
+        "@aws-sdk/credential-provider-http": "^3.972.44",
+        "@aws-sdk/credential-provider-ini": "^3.972.47",
+        "@aws-sdk/credential-provider-process": "^3.972.42",
+        "@aws-sdk/credential-provider-sso": "^3.972.46",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.46",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.42.tgz",
+      "integrity": "sha512-r996IYVtQ7rWa5UfSs3fZLT/Dq/SSgH9wv9zahx9lcg6vvaPPQHFpTy45nZajZu/+OUdEQxEjTn9rOMons59mA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.46.tgz",
+      "integrity": "sha512-vd+UqRbiYLvXXH3kTAuTxq+Vdb3rOgg29/FeB35ETsgdJTTB7x3YuqtpRckATsL5bDRXFVQo0uBj0/vxCJ8hHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/token-providers": "3.1059.0",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.46.tgz",
+      "integrity": "sha512-xuxBbMorygYsbDV6E/tUGQUgIDfhnzxz8uJYX8rByzehI6gLUu8RPsgOpLmh9YWerqeHZxJbqzgheBSB7tpooQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.1059.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.1059.0.tgz",
+      "integrity": "sha512-cSdDFb/O3cQHGg78VxPaNruyy9zGxcoeS7DlwYTdwxmYkE0GXmBRoej5N+q+Av9YWBayZ2n3QsSYhtnUXa/GXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.1059.0",
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/credential-provider-cognito-identity": "^3.972.39",
+        "@aws-sdk/credential-provider-env": "^3.972.42",
+        "@aws-sdk/credential-provider-http": "^3.972.44",
+        "@aws-sdk/credential-provider-ini": "^3.972.47",
+        "@aws-sdk/credential-provider-login": "^3.972.46",
+        "@aws-sdk/credential-provider-node": "^3.972.49",
+        "@aws-sdk/credential-provider-process": "^3.972.42",
+        "@aws-sdk/credential-provider-sso": "^3.972.46",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.46",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dsql-signer": {
+      "version": "3.1059.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dsql-signer/-/dsql-signer-3.1059.0.tgz",
+      "integrity": "sha512-cM5qYVqyELEowOrZR8MoNdIBL6EsmCNFWoEicyCLVY9zFkrVOhKNcBuE3LV6A8EdGpory/Wk9SDQKKNHnP0uiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/credential-provider-node": "^3.972.49",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.14.tgz",
+      "integrity": "sha512-T5CS1r4P27FjkBYIWwVibWqEuq32BbCga2Z5m5OBSdSdi2wPfW2vl6zLWAB/5MeeyC4s2pY/MY3cj2Gd3rgSkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.31",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.31.tgz",
+      "integrity": "sha512-Kn2up9SlG1KC6wRtwf0d7waTGF6rvp9DxYqB54x6UCKdQ6kyaXCqHL4WGb5vUJga5kS8FxnjhY0LqM28aMvnNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1059.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1059.0.tgz",
+      "integrity": "sha512-xql+7YBAE7WYb9xJfY0vcAXM8rJXfClmB2wkt+g/EoLUMog0pOb7o741fE96wFqha0uQTEgTo/5lGGguzavxmw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.16",
+        "@aws-sdk/nested-clients": "^3.997.14",
+        "@aws-sdk/types": "^3.973.10",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.10.tgz",
+      "integrity": "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
+      "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/aurora-dsql-node-postgres-connector": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@aws/aurora-dsql-node-postgres-connector/-/aurora-dsql-node-postgres-connector-0.1.9.tgz",
+      "integrity": "sha512-i8MHzHLdL/1YzsGH6RipLu0U3x8SxCQAtR1VtA7iAhBT4g4yujQ4/qG7HJ5ySAy4XPL/1iNs8m0dLp5LvsqYRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-providers": "^3.894.0",
+        "@aws-sdk/dsql-signer": "^3.940.0",
+        "@smithy/types": "^4.11.0"
+      },
+      "peerDependencies": {
+        "pg": "^8.16.3",
+        "pg-connection-string": "^2.7.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.6.tgz",
+      "integrity": "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.7.tgz",
+      "integrity": "sha512-xj8gq/bjFABAh6qWPSDCYcY3kzQIm4b561C+YnHH4zGq8rOgzQ3Shk+JGlpUxSd41UGiO6FkLdUCtNX1FAeHgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.6.tgz",
+      "integrity": "sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.6.tgz",
+      "integrity": "sha512-3fya8i7GrJilQouk4cZJKdy5k8MWQBpjfXrRNaXDedH8r779tr0jcxyH3+yoTmsluc2+vF4S343yFbnvu8ExDQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.6.tgz",
+      "integrity": "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.8",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.8",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.4.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
@@ -33,7 +33,6 @@
     "@types/express": "^5.0.6",
     "@types/pg": "^8.20.0",
     "@types/supertest": "^7.2.0",
-    "fast-check": "^4.7.0",
     "supertest": "^7.2.2",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "auth-session-management-dsql",
+  "version": "1.0.0",
+  "description": "User Authentication Service with Session Management on Amazon Aurora DSQL",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "ts-node src/index.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "aurora-dsql",
+    "authentication",
+    "session-management",
+    "typescript",
+    "express"
+  ],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "@aws-sdk/credential-providers": "^3.1037.0",
+    "@aws-sdk/dsql-signer": "^3.1037.0",
+    "@aws/aurora-dsql-node-postgres-connector": "^0.1.8",
+    "bcryptjs": "^3.0.3",
+    "express": "^5.2.1",
+    "pg": "^8.20.0"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "^2.4.6",
+    "@types/express": "^5.0.6",
+    "@types/pg": "^8.20.0",
+    "@types/supertest": "^7.2.0",
+    "fast-check": "^4.7.0",
+    "supertest": "^7.2.2",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.5"
+  }
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/app.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/app.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import app from './app';
+
+describe('Express app setup', () => {
+  it('should return 404 for unknown routes', async () => {
+    const res = await request(app).get('/nonexistent');
+    expect(res.status).toBe(404);
+  });
+
+  it('should parse JSON request bodies', async () => {
+    // Create a fresh app to test JSON parsing in isolation
+    const testApp = express();
+    testApp.use(express.json());
+    testApp.post('/echo', (req: Request, res: Response) => {
+      res.json({ received: req.body });
+    });
+
+    const payload = { email: 'test@example.com', password: 'secret123' };
+    const res = await request(testApp)
+      .post('/echo')
+      .send(payload)
+      .set('Content-Type', 'application/json');
+
+    expect(res.status).toBe(200);
+    expect(res.body.received).toEqual(payload);
+  });
+
+  it('should return 500 with generic error from the global error handler', async () => {
+    // Build a standalone app that mirrors the production error handler
+    // to verify the handler shape without mutating the shared app instance.
+    const testApp = express();
+    testApp.use(express.json());
+
+    testApp.get('/trigger-error', (_req: Request, _res: Response, next: NextFunction) => {
+      next(new Error('Something broke'));
+    });
+
+    // Same error handler as in app.ts
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    testApp.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
+      res.status(500).json({
+        success: false,
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'An unexpected error occurred',
+        },
+      });
+    });
+
+    const res = await request(testApp).get('/trigger-error');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: 'An unexpected error occurred',
+      },
+    });
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/app.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/app.ts
@@ -5,11 +5,12 @@
 // Configures the Express application with JSON body parsing, route mounting,
 // and the global error handler.
 //
-// The app is exported in two forms:
-//   1. `createApp(deps)` — factory function that accepts injected services
-//      and middleware, used for testing and production wiring.
-//   2. `default export` — a bare app instance with no routes mounted, kept
-//      for backward compatibility with existing tests.
+// The app is exported via the `createApp(deps)` factory, which accepts
+// injected services and middleware. Tests construct the app with
+// lightweight stubs; production wiring lives in `index.ts`.
+//
+// A bare default export is also provided for tests that exercise app-level
+// behavior (404, JSON parsing) without needing real services.
 //
 // Requirements:
 //   8.7 — Consistent JSON response structure
@@ -34,8 +35,13 @@ import { errorHandler } from './middleware/errorHandler';
 export interface AppDependencies {
   authService: AuthServiceLike;
   sessionService: SessionServiceLike;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  authMiddleware: any;
+  /**
+   * Authentication middleware. Express's `RequestHandler` type covers any
+   * middleware function with the standard `(req, res, next)` signature.
+   * Production middleware is created by `createAuthMiddleware` in
+   * `src/middleware/auth.ts`; tests can inject a no-op or a stub.
+   */
+  authMiddleware: RequestHandler;
 }
 
 /**
@@ -90,8 +96,13 @@ export function createApp(deps: AppDependencies): express.Express {
 }
 
 // ---------------------------------------------------------------------------
-// Default export (bare app for backward compatibility)
+// Default export — bare app for app-level tests
 // ---------------------------------------------------------------------------
+//
+// This bare instance has no routes mounted, only JSON parsing and the global
+// error handler. It exists so app-level tests in `app.test.ts` can verify
+// generic Express behavior (404 for unknown paths, malformed-JSON handling,
+// 500 envelope shape) without constructing service stubs.
 
 const app = express();
 app.use(express.json());

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/app.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/app.ts
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------------
+// Express Application Setup
+// ---------------------------------------------------------------------------
+//
+// Configures the Express application with JSON body parsing, route mounting,
+// and the global error handler.
+//
+// The app is exported in two forms:
+//   1. `createApp(deps)` — factory function that accepts injected services
+//      and middleware, used for testing and production wiring.
+//   2. `default export` — a bare app instance with no routes mounted, kept
+//      for backward compatibility with existing tests.
+//
+// Requirements:
+//   8.7 — Consistent JSON response structure
+//   8.8 — Generic 500 for unhandled errors, no internal details
+// ---------------------------------------------------------------------------
+
+import express, { RequestHandler } from 'express';
+import { createAuthRoutes, AuthServiceLike } from './routes/authRoutes';
+import { createSessionRoutes, SessionServiceLike } from './routes/sessionRoutes';
+import { errorHandler } from './middleware/errorHandler';
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies required to build a fully-wired Express application.
+ *
+ * Each dependency is injected so the app can be tested with lightweight
+ * stubs — no database or AWS credentials needed.
+ */
+export interface AppDependencies {
+  authService: AuthServiceLike;
+  sessionService: SessionServiceLike;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  authMiddleware: any;
+}
+
+/**
+ * Creates a fully-wired Express application.
+ *
+ * Usage:
+ * ```ts
+ * const app = createApp({ authService, sessionService, authMiddleware });
+ * app.listen(3000);
+ * ```
+ *
+ * @param deps - Injected services and middleware.
+ * @returns A configured Express application ready to handle requests.
+ */
+export function createApp(deps: AppDependencies): express.Express {
+  const app = express();
+
+  // -----------------------------------------------------------------------
+  // Middleware
+  // -----------------------------------------------------------------------
+
+  // Parse incoming JSON request bodies.
+  app.use(express.json());
+
+  // -----------------------------------------------------------------------
+  // Routes
+  // -----------------------------------------------------------------------
+
+  // Auth routes: register, login, profile
+  const authRoutes = createAuthRoutes({
+    authService: deps.authService,
+    authMiddleware: deps.authMiddleware,
+  });
+  app.use('/api/auth', authRoutes);
+
+  // Session routes: list, revoke, revoke-all
+  const sessionRoutes = createSessionRoutes({
+    sessionService: deps.sessionService,
+    authMiddleware: deps.authMiddleware,
+  });
+  app.use('/api/sessions', sessionRoutes);
+
+  // -----------------------------------------------------------------------
+  // Global error handler
+  // -----------------------------------------------------------------------
+
+  // Must be registered after all routes so it catches errors from any
+  // route handler or middleware in the chain.
+  app.use(errorHandler);
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Default export (bare app for backward compatibility)
+// ---------------------------------------------------------------------------
+
+const app = express();
+app.use(express.json());
+app.use(errorHandler);
+
+export default app;

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// We mock the DSQL connector so tests don't need real AWS credentials or a
+// live cluster. The mock verifies that the pool is created with the correct
+// configuration and that lifecycle methods behave as expected.
+// ---------------------------------------------------------------------------
+
+const mockEnd = vi.fn().mockResolvedValue(undefined);
+
+// Track constructor calls manually so we can assert on the config passed in.
+const constructorCalls: unknown[] = [];
+
+vi.mock('@aws/aurora-dsql-node-postgres-connector', () => {
+  class MockAuroraDSQLPool {
+    end = mockEnd;
+    constructor(config: unknown) {
+      constructorCalls.push(config);
+    }
+  }
+  return { AuroraDSQLPool: MockAuroraDSQLPool };
+});
+
+// Import *after* the mock is in place so the module picks up the stub.
+import { getPool, closePool } from './connection';
+
+describe('DSQL Connection Pool', () => {
+  const ORIGINAL_ENV = process.env;
+
+  beforeEach(async () => {
+    // Reset the singleton between tests by closing any existing pool
+    await closePool();
+
+    // Isolate environment changes per test
+    process.env = { ...ORIGINAL_ENV };
+    vi.clearAllMocks();
+    constructorCalls.length = 0;
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  // -----------------------------------------------------------------------
+  // getPool()
+  // -----------------------------------------------------------------------
+
+  it('throws when DSQL_ENDPOINT is not set', () => {
+    delete process.env.DSQL_ENDPOINT;
+
+    expect(() => getPool()).toThrow(
+      'DSQL_ENDPOINT environment variable is required but not set'
+    );
+  });
+
+  it('creates a pool with the correct configuration', () => {
+    process.env.DSQL_ENDPOINT = 'my-cluster.dsql.us-east-1.on.aws';
+
+    const pool = getPool();
+
+    expect(constructorCalls).toHaveLength(1);
+    expect(constructorCalls[0]).toEqual({
+      host: 'my-cluster.dsql.us-east-1.on.aws',
+      user: 'admin',
+      database: 'postgres',
+      max: 10,
+      idleTimeoutMillis: 300_000,
+    });
+    expect(pool).toBeDefined();
+  });
+
+  it('returns the same pool instance on subsequent calls', () => {
+    process.env.DSQL_ENDPOINT = 'my-cluster.dsql.us-east-1.on.aws';
+
+    const first = getPool();
+    const second = getPool();
+
+    expect(first).toBe(second);
+    // Constructor should only be called once (singleton)
+    expect(constructorCalls).toHaveLength(1);
+  });
+
+  // -----------------------------------------------------------------------
+  // closePool()
+  // -----------------------------------------------------------------------
+
+  it('calls end() on the pool when closing', async () => {
+    process.env.DSQL_ENDPOINT = 'my-cluster.dsql.us-east-1.on.aws';
+
+    getPool();
+    await closePool();
+
+    expect(mockEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('is safe to call closePool() multiple times', async () => {
+    process.env.DSQL_ENDPOINT = 'my-cluster.dsql.us-east-1.on.aws';
+
+    getPool();
+    await closePool();
+    await closePool();
+
+    // end() should only be called once — the second close is a no-op
+    expect(mockEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows creating a new pool after closing the previous one', async () => {
+    process.env.DSQL_ENDPOINT = 'my-cluster.dsql.us-east-1.on.aws';
+
+    const first = getPool();
+    await closePool();
+
+    const second = getPool();
+
+    expect(first).not.toBe(second);
+    expect(constructorCalls).toHaveLength(2);
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.ts
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------
+// DSQL Connection Pool
+// ---------------------------------------------------------------------------
+//
+// Wraps the official AWS Aurora DSQL connector for node-postgres. The
+// connector extends the standard `pg.Pool` with automatic IAM token
+// generation and refresh, so we don't need to manage credentials manually.
+//
+// The pool is created lazily on the first call to `getPool()` and reused for
+// the lifetime of the process. Call `closePool()` during graceful shutdown to
+// release all connections.
+//
+// Requirements:
+//   9.6 — Use the official DSQL connector for connection management
+//   9.7 — IAM-based database authentication (handled by the connector)
+//  12.3 — Connection pool with bounded size
+//  12.4 — Idle timeout well below the 1-hour DSQL connection limit
+// ---------------------------------------------------------------------------
+
+import { AuroraDSQLPool } from '@aws/aurora-dsql-node-postgres-connector';
+
+/**
+ * Singleton pool instance. Created on the first call to `getPool()`.
+ */
+let pool: AuroraDSQLPool | null = null;
+
+/**
+ * Returns the shared DSQL connection pool, creating it on first access.
+ *
+ * The pool is configured with:
+ * - `host`              — read from the `DSQL_ENDPOINT` environment variable
+ * - `user`              — `'admin'` (DSQL's default IAM-authenticated user)
+ * - `database`          — `'postgres'` (DSQL's fixed database name)
+ * - `max`               — 10 concurrent connections
+ * - `idleTimeoutMillis` — 300 000 ms (5 minutes), well under the 1-hour
+ *                         DSQL connection timeout so connections are recycled
+ *                         before they expire
+ *
+ * @throws {Error} If `DSQL_ENDPOINT` is not set in the environment.
+ */
+export function getPool(): AuroraDSQLPool {
+  if (pool) {
+    return pool;
+  }
+
+  const host = process.env.DSQL_ENDPOINT;
+  if (!host) {
+    throw new Error(
+      'DSQL_ENDPOINT environment variable is required but not set'
+    );
+  }
+
+  pool = new AuroraDSQLPool({
+    host,
+    user: 'admin',
+    database: 'postgres',
+    max: 10,
+    idleTimeoutMillis: 300_000, // 5 minutes
+  });
+
+  return pool;
+}
+
+/**
+ * Closes the connection pool and releases all connections.
+ *
+ * Safe to call multiple times — subsequent calls are no-ops once the pool
+ * has been shut down. Typically invoked from a SIGTERM / SIGINT handler
+ * during graceful shutdown.
+ */
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
@@ -60,9 +60,10 @@ describe('runMigrations', () => {
 
     await runMigrations(pool);
 
-    // We expect 4 separate transactions: users table, sessions table,
-    // and two indexes.
-    expect(clients).toHaveLength(4);
+    // We expect 3 separate transactions: users table, sessions table,
+    // and the user_id index. The token_hash UNIQUE constraint already
+    // creates a backing index, so we deliberately do NOT add a second.
+    expect(clients).toHaveLength(3);
 
     // Each client should have received BEGIN → DDL → COMMIT
     for (const client of clients) {
@@ -110,14 +111,14 @@ describe('runMigrations', () => {
     expect(ddl).toContain('ON sessions (user_id)');
   });
 
-  it('creates the token_hash index fourth', async () => {
+  it('does not add a redundant token_hash index (UNIQUE constraint already creates one)', async () => {
     const { pool, clients } = createMockPool();
 
     await runMigrations(pool);
 
-    const ddl = clients[3].queries[1];
-    expect(ddl).toContain('CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_token_hash');
-    expect(ddl).toContain('ON sessions (token_hash)');
+    const allDdl = clients.map((c) => c.queries[1]).join('\n');
+    expect(allDdl).not.toContain('idx_sessions_token_hash');
+    expect(allDdl).not.toMatch(/CREATE INDEX[^\n]*ON sessions \(token_hash\)/);
   });
 
   it('releases every client back to the pool', async () => {

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runMigrations, PoolLike, ClientLike } from './migrate';
+
+// ---------------------------------------------------------------------------
+// Helpers — lightweight mock pool and client
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock client that records every SQL statement it receives.
+ * Optionally accepts a callback that can throw to simulate failures.
+ */
+function createMockClient(
+  onQuery?: (sql: string) => void
+): ClientLike & { queries: string[] } {
+  const queries: string[] = [];
+  return {
+    queries,
+    query: vi.fn(async (sql: string) => {
+      queries.push(sql);
+      onQuery?.(sql);
+    }),
+    release: vi.fn(),
+  };
+}
+
+/**
+ * Creates a mock pool that returns a fresh mock client for each `connect()`
+ * call. Returns the pool and an array of all clients it has handed out.
+ */
+function createMockPool(): {
+  pool: PoolLike;
+  clients: ReturnType<typeof createMockClient>[];
+} {
+  const clients: ReturnType<typeof createMockClient>[] = [];
+  const pool: PoolLike = {
+    connect: vi.fn(async () => {
+      const client = createMockClient();
+      clients.push(client);
+      return client;
+    }),
+  };
+  return { pool, clients };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runMigrations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // Happy path
+  // -----------------------------------------------------------------------
+
+  it('executes each DDL statement in its own transaction', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool);
+
+    // We expect 4 separate transactions: users table, sessions table,
+    // and two indexes.
+    expect(clients).toHaveLength(4);
+
+    // Each client should have received BEGIN → DDL → COMMIT
+    for (const client of clients) {
+      expect(client.queries[0]).toBe('BEGIN');
+      expect(client.queries[2]).toBe('COMMIT');
+      expect(client.queries).toHaveLength(3);
+    }
+  });
+
+  it('creates the users table first', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool);
+
+    const ddl = clients[0].queries[1];
+    expect(ddl).toContain('CREATE TABLE IF NOT EXISTS users');
+    expect(ddl).toContain('id UUID PRIMARY KEY');
+    expect(ddl).toContain('email VARCHAR(254) NOT NULL UNIQUE');
+    expect(ddl).toContain('password_hash VARCHAR(72) NOT NULL');
+    expect(ddl).toContain('created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()');
+  });
+
+  it('creates the sessions table second', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool);
+
+    const ddl = clients[1].queries[1];
+    expect(ddl).toContain('CREATE TABLE IF NOT EXISTS sessions');
+    expect(ddl).toContain('id UUID PRIMARY KEY');
+    expect(ddl).toContain('user_id UUID NOT NULL');
+    expect(ddl).toContain('token_hash VARCHAR(64) NOT NULL UNIQUE');
+    expect(ddl).toContain('expires_at TIMESTAMPTZ NOT NULL');
+    expect(ddl).toContain('revoked_at TIMESTAMPTZ');
+    expect(ddl).toContain('client_metadata TEXT');
+  });
+
+  it('creates the user_id index third', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool);
+
+    const ddl = clients[2].queries[1];
+    expect(ddl).toContain('CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_user_id');
+    expect(ddl).toContain('ON sessions (user_id)');
+  });
+
+  it('creates the token_hash index fourth', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool);
+
+    const ddl = clients[3].queries[1];
+    expect(ddl).toContain('CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_token_hash');
+    expect(ddl).toContain('ON sessions (token_hash)');
+  });
+
+  it('releases every client back to the pool', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool);
+
+    for (const client of clients) {
+      expect(client.release).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // Error handling
+  // -----------------------------------------------------------------------
+
+  it('rolls back and re-throws when a DDL statement fails', async () => {
+    const ddlError = new Error('relation already exists');
+    let callCount = 0;
+
+    const failingPool: PoolLike = {
+      connect: vi.fn(async () => {
+        callCount++;
+        // Fail on the second DDL (sessions table)
+        if (callCount === 2) {
+          return createMockClient((sql) => {
+            if (sql !== 'BEGIN' && sql !== 'ROLLBACK') {
+              throw ddlError;
+            }
+          });
+        }
+        return createMockClient();
+      }),
+    };
+
+    await expect(runMigrations(failingPool)).rejects.toThrow(
+      'relation already exists'
+    );
+  });
+
+  it('rolls back the transaction on failure before releasing the client', async () => {
+    const ddlError = new Error('syntax error');
+    const failingClient = createMockClient((sql) => {
+      if (sql !== 'BEGIN' && sql !== 'ROLLBACK') {
+        throw ddlError;
+      }
+    });
+
+    const failingPool: PoolLike = {
+      connect: vi.fn(async () => failingClient),
+    };
+
+    await expect(runMigrations(failingPool)).rejects.toThrow('syntax error');
+
+    // Should have attempted ROLLBACK after the failure
+    expect(failingClient.queries).toContain('ROLLBACK');
+    // Client must still be released even after an error
+    expect(failingClient.release).toHaveBeenCalledTimes(1);
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------
+// Database Migrator
+// ---------------------------------------------------------------------------
+//
+// Runs DDL statements to create the tables and indexes required by the
+// authentication service. Aurora DSQL has a strict constraint: each DDL
+// statement must execute in its own, separate transaction. You cannot batch
+// multiple DDL statements or mix DDL with DML in a single transaction.
+//
+// This module executes each CREATE TABLE and CREATE INDEX statement in an
+// independent transaction, committing after each one. All statements use
+// IF NOT EXISTS / IF NOT EXISTS so the migrator is safe to run repeatedly
+// (idempotent).
+//
+// Requirements:
+//   9.1 — Users table schema
+//   9.2 — Sessions table schema
+//   9.8 — Each DDL in its own transaction
+//   9.9 — No extensions, triggers, sequences, etc.
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for a connection pool. Using a narrow type instead of
+ * the concrete `AuroraDSQLPool` class makes the migrator easy to test with
+ * a lightweight mock — no AWS credentials required.
+ */
+export interface PoolLike {
+  connect(): Promise<ClientLike>;
+}
+
+/**
+ * Minimal interface for a database client obtained from the pool.
+ */
+export interface ClientLike {
+  query(sql: string): Promise<unknown>;
+  release(): void;
+}
+
+// ---------------------------------------------------------------------------
+// DDL Statements
+// ---------------------------------------------------------------------------
+
+/**
+ * Each string is a single DDL statement that will be executed inside its own
+ * transaction. Order matters: tables must be created before their indexes.
+ */
+const DDL_STATEMENTS: string[] = [
+  // 1. Users table
+  `CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY,
+  email VARCHAR(254) NOT NULL UNIQUE,
+  password_hash VARCHAR(72) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+)`,
+
+  // 2. Sessions table
+  `CREATE TABLE IF NOT EXISTS sessions (
+  id UUID PRIMARY KEY,
+  user_id UUID NOT NULL,
+  token_hash VARCHAR(64) NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  client_metadata TEXT
+)`,
+
+  // 3. Index on sessions.user_id for fast lookups by user
+  // Aurora DSQL requires ASYNC index creation — indexes are built in the
+  // background without blocking reads or writes.
+  `CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_user_id ON sessions (user_id)`,
+
+  // 4. Index on sessions.token_hash for fast token validation
+  `CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_token_hash ON sessions (token_hash)`,
+];
+
+// ---------------------------------------------------------------------------
+// Migration Runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes all DDL migrations against the provided connection pool.
+ *
+ * Each statement runs inside its own transaction (BEGIN → DDL → COMMIT) to
+ * satisfy Aurora DSQL's one-DDL-per-transaction constraint. If any statement
+ * fails, the transaction is rolled back and the error is re-thrown so the
+ * caller can decide how to handle it.
+ *
+ * @param pool - A connection pool (or pool-like mock) that provides `connect()`.
+ */
+export async function runMigrations(pool: PoolLike): Promise<void> {
+  for (const sql of DDL_STATEMENTS) {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(sql);
+      await client.query('COMMIT');
+    } catch (error) {
+      // Roll back the failed transaction so the connection is left in a
+      // clean state before being returned to the pool.
+      await client.query('ROLLBACK');
+      throw error;
+    } finally {
+      client.release();
+    }
+  }
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
@@ -64,13 +64,23 @@ const DDL_STATEMENTS: string[] = [
   client_metadata TEXT
 )`,
 
-  // 3. Index on sessions.user_id for fast lookups by user
+  // 3. Index on sessions.user_id for fast lookups by user.
+  //
   // Aurora DSQL requires ASYNC index creation — indexes are built in the
   // background without blocking reads or writes.
+  //
+  // IMPORTANT: `CREATE INDEX ASYNC` returns immediately; the index will
+  // not be VALID until the background build completes. Reads against
+  // `sessions.user_id` will fall back to a full scan until then. Wait for
+  // index validity before relying on the index for performance —
+  // see https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-features.html
+  // for guidance on monitoring async index build status.
+  //
+  // Note: `sessions.token_hash` is intentionally NOT given an explicit
+  // CREATE INDEX statement. The `UNIQUE` constraint declared in the
+  // `sessions` table above already creates a backing unique index — adding
+  // a second index on the same column is redundant and wastes write IOPS.
   `CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_user_id ON sessions (user_id)`,
-
-  // 4. Index on sessions.token_hash for fast token validation
-  `CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_token_hash ON sessions (token_hash)`,
 ];
 
 // ---------------------------------------------------------------------------
@@ -95,9 +105,14 @@ export async function runMigrations(pool: PoolLike): Promise<void> {
       await client.query(sql);
       await client.query('COMMIT');
     } catch (error) {
-      // Roll back the failed transaction so the connection is left in a
-      // clean state before being returned to the pool.
-      await client.query('ROLLBACK');
+      // Best-effort rollback. If ROLLBACK itself throws (e.g. dead
+      // connection), preserve the *original* error — the SQLSTATE from the
+      // failed DDL is more useful for debugging than the rollback failure.
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // swallow — re-throwing the original error below is more useful
+      }
       throw error;
     } finally {
       client.release();

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/index.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/index.ts
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------
+// Application Entry Point
+// ---------------------------------------------------------------------------
+//
+// Initializes the DSQL connection pool, runs database migrations, wires up
+// all application dependencies, and starts the Express server.
+//
+// Graceful shutdown is handled via SIGTERM and SIGINT signals — the server
+// stops accepting new connections and the connection pool is drained before
+// the process exits.
+//
+// Requirements:
+//   9.5 — Strong consistency (immediate read-after-write)
+//   9.6 — Use the official DSQL connector for connection management
+//   9.7 — IAM-based database authentication
+//  12.3 — Connection pool with bounded size
+// ---------------------------------------------------------------------------
+
+import { getPool, closePool } from './db/connection';
+import { runMigrations } from './db/migrate';
+import { createUserRepository } from './repositories/userRepository';
+import { createSessionRepository } from './repositories/sessionRepository';
+import { createSessionService } from './services/sessionService';
+import { createAuthService } from './services/authService';
+import { createAuthMiddleware } from './middleware/auth';
+import { createApp } from './app';
+
+// ---------------------------------------------------------------------------
+// Environment validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates that all required environment variables are set before the
+ * application attempts to connect to Aurora DSQL. Fails fast with a clear
+ * error message so misconfiguration is caught at startup, not at runtime.
+ */
+function validateEnvironment(): void {
+  if (!process.env.DSQL_ENDPOINT) {
+    console.error(
+      'ERROR: DSQL_ENDPOINT environment variable is required but not set.\n' +
+        'Set it to your Aurora DSQL cluster endpoint, e.g.:\n' +
+        '  export DSQL_ENDPOINT="your-cluster-id.dsql.us-east-1.on.aws"',
+    );
+    process.exit(1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  // Step 1 — Validate required environment variables.
+  validateEnvironment();
+
+  // Step 2 — Get the DSQL connection pool (Requirement 9.6, 9.7, 12.3).
+  // The pool uses IAM-based authentication via the official DSQL connector.
+  const pool = getPool();
+
+  // Step 3 — Run database migrations (creating tables and indexes).
+  // Each DDL statement runs in its own transaction as required by DSQL.
+  console.log('Running database migrations (creating tables and indexes)...');
+  await runMigrations(pool);
+  console.log('Database migrations complete.');
+
+  // Step 4 — Create all application dependencies.
+  const userRepository = createUserRepository(pool);
+  const sessionRepository = createSessionRepository(pool);
+  const sessionService = createSessionService({ sessionRepository });
+  const authService = createAuthService({ userRepository, sessionService });
+  const authMiddleware = createAuthMiddleware({ sessionService, userRepository });
+
+  // Step 5 — Create the fully-wired Express application.
+  const app = createApp({ authService, sessionService, authMiddleware });
+
+  // Step 6 — Start the HTTP server.
+  const PORT = parseInt(process.env.PORT || '3000', 10);
+  const server = app.listen(PORT, () => {
+    console.log(`Auth service listening on port ${PORT}`);
+  });
+
+  // Step 7 — Register graceful shutdown handlers.
+  // On SIGTERM or SIGINT, stop accepting new connections, close the pool,
+  // and exit cleanly.
+  const shutdown = async (signal: string) => {
+    console.log(`\n${signal} received — shutting down gracefully...`);
+
+    server.close(async () => {
+      console.log('HTTP server closed.');
+
+      await closePool();
+      console.log('Connection pool closed.');
+
+      process.exit(0);
+    });
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+}
+
+// ---------------------------------------------------------------------------
+// Start the application
+// ---------------------------------------------------------------------------
+
+main().catch((error) => {
+  console.error('Failed to start the application:', error);
+  process.exit(1);
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/index.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/index.ts
@@ -16,6 +16,7 @@
 //  12.3 — Connection pool with bounded size
 // ---------------------------------------------------------------------------
 
+import { RequestHandler } from 'express';
 import { getPool, closePool } from './db/connection';
 import { runMigrations } from './db/migrate';
 import { createUserRepository } from './repositories/userRepository';
@@ -71,7 +72,15 @@ async function main(): Promise<void> {
   const authMiddleware = createAuthMiddleware({ sessionService, userRepository });
 
   // Step 5 — Create the fully-wired Express application.
-  const app = createApp({ authService, sessionService, authMiddleware });
+  // The middleware augments the request with `user` and `sessionId` after
+  // running. Cast to the standard `RequestHandler` signature for wiring;
+  // the augmented properties are read inside route handlers via an
+  // `AuthenticatedRequest` cast.
+  const app = createApp({
+    authService,
+    sessionService,
+    authMiddleware: authMiddleware as RequestHandler,
+  });
 
   // Step 6 — Start the HTTP server.
   const PORT = parseInt(process.env.PORT || '3000', 10);

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.test.ts
@@ -1,0 +1,204 @@
+// ---------------------------------------------------------------------------
+// Auth Middleware — Unit Tests
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi } from 'vitest';
+import { Response, NextFunction } from 'express';
+import { createAuthMiddleware, SessionServiceLike, UserRepositoryLike } from './auth';
+import { AuthenticatedRequest } from '../types';
+import { InvalidSessionError, SessionExpiredError } from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers — build minimal Express-like objects for middleware testing
+// ---------------------------------------------------------------------------
+
+function mockReq(headers: Record<string, string> = {}): AuthenticatedRequest {
+  return {
+    headers,
+    user: undefined as unknown as { id: string; email: string },
+    sessionId: undefined as unknown as string,
+  } as unknown as AuthenticatedRequest;
+}
+
+function mockRes(): Response {
+  return {} as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Stub factories
+// ---------------------------------------------------------------------------
+
+function createStubs(overrides?: {
+  validateSession?: SessionServiceLike['validateSession'];
+  findById?: UserRepositoryLike['findById'];
+}) {
+  const sessionService: SessionServiceLike = {
+    validateSession: overrides?.validateSession ??
+      vi.fn().mockResolvedValue({ userId: 'user-1', sessionId: 'session-1' }),
+  };
+
+  const userRepository: UserRepositoryLike = {
+    findById: overrides?.findById ??
+      vi.fn().mockResolvedValue({ id: 'user-1', email: 'alice@example.com' }),
+  };
+
+  return { sessionService, userRepository };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('createAuthMiddleware', () => {
+  it('attaches user and sessionId to the request for a valid token', async () => {
+    const { sessionService, userRepository } = createStubs();
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer valid-token-abc' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith();
+    expect(req.user).toEqual({ id: 'user-1', email: 'alice@example.com' });
+    expect(req.sessionId).toBe('session-1');
+    expect(sessionService.validateSession).toHaveBeenCalledWith('valid-token-abc');
+    expect(userRepository.findById).toHaveBeenCalledWith('user-1');
+  });
+
+  it('calls next with InvalidSessionError when Authorization header is missing', async () => {
+    const { sessionService, userRepository } = createStubs();
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({});
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(InvalidSessionError));
+    expect((next.mock.calls[0][0] as InvalidSessionError).message).toBe(
+      'Authorization header is required',
+    );
+  });
+
+  it('calls next with InvalidSessionError when Authorization header has wrong scheme', async () => {
+    const { sessionService, userRepository } = createStubs();
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Basic abc123' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(InvalidSessionError));
+    expect((next.mock.calls[0][0] as InvalidSessionError).message).toBe(
+      'Authorization header is required',
+    );
+  });
+
+  it('calls next with InvalidSessionError when Bearer token is empty', async () => {
+    const { sessionService, userRepository } = createStubs();
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer ' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(InvalidSessionError));
+    expect((next.mock.calls[0][0] as InvalidSessionError).message).toBe(
+      'Authorization header is required',
+    );
+  });
+
+  it('propagates InvalidSessionError from session service for invalid tokens', async () => {
+    const { sessionService, userRepository } = createStubs({
+      validateSession: vi.fn().mockRejectedValue(new InvalidSessionError()),
+    });
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer bad-token' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(InvalidSessionError));
+    expect((next.mock.calls[0][0] as InvalidSessionError).message).toBe('Invalid session');
+  });
+
+  it('propagates SessionExpiredError from session service for expired tokens', async () => {
+    const { sessionService, userRepository } = createStubs({
+      validateSession: vi.fn().mockRejectedValue(new SessionExpiredError()),
+    });
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer expired-token' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(SessionExpiredError));
+    expect((next.mock.calls[0][0] as SessionExpiredError).message).toBe('Session has expired');
+  });
+
+  it('calls next with InvalidSessionError when user is not found', async () => {
+    const { sessionService, userRepository } = createStubs({
+      findById: vi.fn().mockResolvedValue(null),
+    });
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer valid-token' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(expect.any(InvalidSessionError));
+    expect((next.mock.calls[0][0] as InvalidSessionError).message).toBe('User not found');
+  });
+
+  it('does not call userRepository.findById when session validation fails', async () => {
+    const findById = vi.fn();
+    const { sessionService } = createStubs({
+      validateSession: vi.fn().mockRejectedValue(new InvalidSessionError()),
+    });
+    const userRepository: UserRepositoryLike = { findById };
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer bad-token' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(findById).not.toHaveBeenCalled();
+  });
+
+  it('propagates unexpected errors from session service', async () => {
+    const unexpectedError = new Error('Database connection lost');
+    const { sessionService, userRepository } = createStubs({
+      validateSession: vi.fn().mockRejectedValue(unexpectedError),
+    });
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer some-token' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(unexpectedError);
+  });
+
+  it('propagates unexpected errors from user repository', async () => {
+    const unexpectedError = new Error('Database timeout');
+    const { sessionService, userRepository } = createStubs({
+      findById: vi.fn().mockRejectedValue(unexpectedError),
+    });
+    const middleware = createAuthMiddleware({ sessionService, userRepository });
+
+    const req = mockReq({ authorization: 'Bearer some-token' });
+    const next = vi.fn();
+
+    await middleware(req, mockRes(), next);
+
+    expect(next).toHaveBeenCalledWith(unexpectedError);
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.test.ts
@@ -92,7 +92,7 @@ describe('createAuthMiddleware', () => {
 
     expect(next).toHaveBeenCalledWith(expect.any(InvalidSessionError));
     expect((next.mock.calls[0][0] as InvalidSessionError).message).toBe(
-      'Authorization header is required',
+      'Authorization header must use the Bearer scheme',
     );
   });
 
@@ -106,8 +106,10 @@ describe('createAuthMiddleware', () => {
     await middleware(req, mockRes(), next);
 
     expect(next).toHaveBeenCalledWith(expect.any(InvalidSessionError));
+    // Distinct from the "no header" message — this case is "header is
+    // present and uses the Bearer scheme, but the token slot is empty".
     expect((next.mock.calls[0][0] as InvalidSessionError).message).toBe(
-      'Authorization header is required',
+      'Bearer token is missing from Authorization header',
     );
   });
 

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.ts
@@ -90,14 +90,24 @@ export function createAuthMiddleware(deps: {
     // Step 1 — Extract the Bearer token from the Authorization header.
     const authHeader = req.headers.authorization;
 
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    if (!authHeader) {
       return next(new InvalidSessionError('Authorization header is required'));
     }
 
-    const token = authHeader.slice(7); // Remove "Bearer " prefix
+    if (!authHeader.startsWith('Bearer ')) {
+      return next(
+        new InvalidSessionError(
+          'Authorization header must use the Bearer scheme',
+        ),
+      );
+    }
+
+    const token = authHeader.slice(7).trim(); // Remove "Bearer " prefix and any padding
 
     if (token.length === 0) {
-      return next(new InvalidSessionError('Authorization header is required'));
+      return next(
+        new InvalidSessionError('Bearer token is missing from Authorization header'),
+      );
     }
 
     try {

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/auth.ts
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------
+// Auth Middleware
+// ---------------------------------------------------------------------------
+//
+// Extracts the session token from the `Authorization: Bearer <token>` header,
+// validates it via the Session Service, and attaches the authenticated user
+// context to the request object. Protected routes use this middleware to
+// ensure only authenticated users can access them.
+//
+// Dependencies (Session Service, User Repository) are injected via a factory
+// function so the middleware is easy to test without a real database.
+//
+// Requirements:
+//   4.1 — Query session by token
+//   4.2 — Validate active, non-expired session
+//   4.3 — Reject expired sessions
+//   4.4 — Reject non-existent sessions
+//   4.5 — Reject revoked sessions
+// ---------------------------------------------------------------------------
+
+import { Response, NextFunction } from 'express';
+import { AuthenticatedRequest } from '../types';
+import { InvalidSessionError } from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces (narrow types for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for the Session Service.
+ *
+ * Only the `validateSession` method is needed by the auth middleware.
+ */
+export interface SessionServiceLike {
+  validateSession(token: string): Promise<{ userId: string; sessionId: string }>;
+}
+
+/**
+ * Minimal interface for the User Repository.
+ *
+ * Only the `findById` method is needed to look up the user's email after
+ * session validation.
+ */
+export interface UserRepositoryLike {
+  findById(id: string): Promise<{ id: string; email: string } | null>;
+}
+
+// ---------------------------------------------------------------------------
+// Auth Middleware factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an Express middleware that authenticates requests using Bearer tokens.
+ *
+ * Flow:
+ *   1. Extract the token from the `Authorization: Bearer <token>` header.
+ *   2. If no token is present, reject with an `InvalidSessionError`.
+ *   3. Validate the token via the Session Service.
+ *   4. Look up the user by ID to get their email.
+ *   5. Attach `user` and `sessionId` to the request object.
+ *   6. Call `next()` to proceed to the route handler.
+ *
+ * Usage:
+ * ```ts
+ * const authMiddleware = createAuthMiddleware({
+ *   sessionService,
+ *   userRepository,
+ * });
+ *
+ * router.get('/protected', authMiddleware, (req, res) => {
+ *   const { user, sessionId } = req as AuthenticatedRequest;
+ *   // ...
+ * });
+ * ```
+ *
+ * @param deps.sessionService  - Service for session validation.
+ * @param deps.userRepository  - Repository for user lookups.
+ */
+export function createAuthMiddleware(deps: {
+  sessionService: SessionServiceLike;
+  userRepository: UserRepositoryLike;
+}) {
+  const { sessionService, userRepository } = deps;
+
+  return async (
+    req: AuthenticatedRequest,
+    _res: Response,
+    next: NextFunction,
+  ): Promise<void> => {
+    // Step 1 — Extract the Bearer token from the Authorization header.
+    const authHeader = req.headers.authorization;
+
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      return next(new InvalidSessionError('Authorization header is required'));
+    }
+
+    const token = authHeader.slice(7); // Remove "Bearer " prefix
+
+    if (token.length === 0) {
+      return next(new InvalidSessionError('Authorization header is required'));
+    }
+
+    try {
+      // Step 2 — Validate the session token (Requirements 4.1–4.5).
+      // The session service throws InvalidSessionError or SessionExpiredError
+      // for invalid, revoked, or expired tokens.
+      const { userId, sessionId } = await sessionService.validateSession(token);
+
+      // Step 3 — Look up the user to get their email for the request context.
+      const user = await userRepository.findById(userId);
+
+      if (!user) {
+        return next(new InvalidSessionError('User not found'));
+      }
+
+      // Step 4 — Attach the authenticated context to the request.
+      req.user = { id: user.id, email: user.email };
+      req.sessionId = sessionId;
+
+      // Step 5 — Proceed to the next middleware or route handler.
+      next();
+    } catch (error) {
+      // Let InvalidSessionError and SessionExpiredError propagate to the
+      // global error handler, which maps them to 401 responses.
+      next(error);
+    }
+  };
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/errorHandler.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/errorHandler.test.ts
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------
+// Error Handler Middleware — Unit Tests
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { errorHandler } from './errorHandler';
+import {
+  ValidationError,
+  AuthenticationError,
+  ConflictError,
+  SessionExpiredError,
+  InvalidSessionError,
+  ServiceUnavailableError,
+} from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Helper — build a test app that throws a given error
+// ---------------------------------------------------------------------------
+
+function buildApp(error: Error) {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/test', (_req: Request, _res: Response, next: NextFunction) => {
+    next(error);
+  });
+
+  app.use(errorHandler);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('errorHandler', () => {
+  it('maps ValidationError to 400 with VALIDATION_ERROR code', async () => {
+    const app = buildApp(new ValidationError('Email is required'));
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'Email is required',
+      },
+    });
+  });
+
+  it('maps AuthenticationError to 401 with AUTHENTICATION_FAILED code', async () => {
+    const app = buildApp(new AuthenticationError());
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'AUTHENTICATION_FAILED',
+        message: 'Invalid email or password',
+      },
+    });
+  });
+
+  it('maps ConflictError to 409 with EMAIL_ALREADY_EXISTS code', async () => {
+    const app = buildApp(new ConflictError());
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'EMAIL_ALREADY_EXISTS',
+        message: 'Email already exists',
+      },
+    });
+  });
+
+  it('maps SessionExpiredError to 401 with INVALID_SESSION code', async () => {
+    const app = buildApp(new SessionExpiredError());
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'INVALID_SESSION',
+        message: 'Session has expired',
+      },
+    });
+  });
+
+  it('maps InvalidSessionError to 401 with INVALID_SESSION code', async () => {
+    const app = buildApp(new InvalidSessionError());
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'INVALID_SESSION',
+        message: 'Invalid session',
+      },
+    });
+  });
+
+  it('maps ServiceUnavailableError to 503 with SERVICE_UNAVAILABLE code', async () => {
+    const app = buildApp(new ServiceUnavailableError());
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'SERVICE_UNAVAILABLE',
+        message: 'Service temporarily unavailable',
+      },
+    });
+  });
+
+  it('maps unknown errors to 500 with generic message', async () => {
+    // Suppress console.error output during this test
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const app = buildApp(new Error('Database connection lost'));
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({
+      success: false,
+      error: {
+        code: 'INTERNAL_ERROR',
+        message: 'An unexpected error occurred',
+      },
+    });
+
+    // Verify the full error was logged internally
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Unhandled error:',
+      expect.any(Error),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not expose internal error details for unknown errors', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const app = buildApp(new Error('SELECT * FROM secret_table'));
+
+    const res = await request(app).get('/test');
+
+    // The response should not contain the internal error message
+    expect(res.body.error.message).toBe('An unexpected error occurred');
+    expect(JSON.stringify(res.body)).not.toContain('secret_table');
+
+    vi.restoreAllMocks();
+  });
+
+  it('preserves custom messages on AppError subclasses', async () => {
+    const app = buildApp(new ValidationError('Password must be at least 8 characters'));
+
+    const res = await request(app).get('/test');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toBe('Password must be at least 8 characters');
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/errorHandler.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/errorHandler.ts
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// Global Error Handler Middleware
+// ---------------------------------------------------------------------------
+//
+// Express error-handling middleware that maps application errors to the
+// standard API response envelope. Custom error classes (AppError subclasses)
+// carry their own HTTP status code and machine-readable error code, so the
+// handler simply reads those properties and formats the response.
+//
+// Unrecognised errors are treated as 500 Internal Server Error with a
+// generic message — no stack traces or internal details are ever exposed
+// to the client (Requirement 8.8).
+//
+// Requirements:
+//   8.7 — Consistent JSON response structure
+//   8.8 — Generic 500 for unhandled errors, no internal details
+// ---------------------------------------------------------------------------
+
+import { Request, Response, NextFunction } from 'express';
+import { AppError } from '../utils/errors';
+import { ApiResponse } from '../types';
+
+/**
+ * Express error-handling middleware.
+ *
+ * Must have exactly four parameters so Express recognises it as an error
+ * handler rather than a regular middleware.
+ *
+ * Behaviour:
+ *   1. If the error is an `AppError` subclass, use its `statusCode` and
+ *      `code` to build the response.
+ *   2. Otherwise, log the full error for debugging and return a generic
+ *      500 response with no internal details.
+ */
+export function errorHandler(
+  err: Error,
+  _req: Request,
+  res: Response,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _next: NextFunction,
+): void {
+  // --- Known application errors (AppError subclasses) ---
+  if (err instanceof AppError) {
+    const body: ApiResponse<never> = {
+      success: false,
+      error: {
+        code: err.code,
+        message: err.message,
+      },
+    };
+
+    res.status(err.statusCode).json(body);
+    return;
+  }
+
+  // --- Unhandled / unexpected errors ---
+  // Log the full error internally for debugging, but never expose details
+  // to the client (Requirement 8.8).
+  console.error('Unhandled error:', err);
+
+  const body: ApiResponse<never> = {
+    success: false,
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: 'An unexpected error occurred',
+    },
+  };
+
+  res.status(500).json(body);
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/validator.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/validator.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Request, Response, NextFunction } from 'express';
+import {
+  createValidator,
+  validateRegistration,
+  validateLogin,
+  validateSessionId,
+  validateEmail,
+  validatePassword,
+  validateUuid,
+} from './validator';
+import { ValidationError } from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers — build minimal Express-like objects for middleware testing
+// ---------------------------------------------------------------------------
+
+function mockReq(body: Record<string, unknown> = {}, params: Record<string, string> = {}): Request {
+  return { body, params } as unknown as Request;
+}
+
+function mockRes(): Response {
+  return {} as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Unit helpers (validateEmail, validatePassword, validateUuid)
+// ---------------------------------------------------------------------------
+
+describe('validateEmail', () => {
+  it('rejects missing / empty values', () => {
+    expect(validateEmail(undefined)).toBe('Email is required');
+    expect(validateEmail(null)).toBe('Email is required');
+    expect(validateEmail('')).toBe('Email is required');
+    expect(validateEmail('   ')).toBe('Email is required');
+  });
+
+  it('rejects emails without @', () => {
+    expect(validateEmail('userexample.com')).toBe('Email format is invalid');
+  });
+
+  it('rejects emails with empty local part', () => {
+    expect(validateEmail('@example.com')).toBe('Email format is invalid');
+  });
+
+  it('rejects emails with no domain dot', () => {
+    expect(validateEmail('user@localhost')).toBe('Email format is invalid');
+  });
+
+  it('rejects emails with domain ending in dot', () => {
+    expect(validateEmail('user@example.')).toBe('Email format is invalid');
+  });
+
+  it('rejects emails exceeding 254 characters', () => {
+    const long = 'a'.repeat(245) + '@test.com'; // 254 chars exactly is fine
+    expect(validateEmail(long)).toBeNull();
+
+    const tooLong = 'a'.repeat(246) + '@test.com'; // 255 chars
+    expect(validateEmail(tooLong)).toBe('Email must not exceed 254 characters');
+  });
+
+  it('rejects emails with multiple @ signs', () => {
+    expect(validateEmail('user@@example.com')).toBe('Email format is invalid');
+    expect(validateEmail('user@foo@example.com')).toBe('Email format is invalid');
+  });
+
+  it('accepts valid emails', () => {
+    expect(validateEmail('user@example.com')).toBeNull();
+    expect(validateEmail('USER@Example.COM')).toBeNull();
+    expect(validateEmail('  user@example.com  ')).toBeNull();
+  });
+});
+
+describe('validatePassword', () => {
+  it('rejects missing / empty values', () => {
+    expect(validatePassword(undefined)).toBe('Password is required');
+    expect(validatePassword(null)).toBe('Password is required');
+    expect(validatePassword('')).toBe('Password is required');
+  });
+
+  it('rejects passwords shorter than 8 chars when length enforced', () => {
+    expect(validatePassword('short', true)).toBe('Password must be at least 8 characters');
+  });
+
+  it('rejects passwords longer than 128 chars when length enforced', () => {
+    expect(validatePassword('a'.repeat(129), true)).toBe('Password must not exceed 128 characters');
+  });
+
+  it('accepts valid passwords with length enforcement', () => {
+    expect(validatePassword('abcdefgh', true)).toBeNull();
+    expect(validatePassword('a'.repeat(128), true)).toBeNull();
+  });
+
+  it('skips length checks when requireLength is false', () => {
+    expect(validatePassword('short', false)).toBeNull();
+    expect(validatePassword('a'.repeat(200), false)).toBeNull();
+  });
+});
+
+describe('validateUuid', () => {
+  it('rejects missing values', () => {
+    expect(validateUuid(undefined, 'ID')).toBe('ID is required');
+    expect(validateUuid('', 'ID')).toBe('ID is required');
+  });
+
+  it('rejects non-UUID strings', () => {
+    expect(validateUuid('not-a-uuid', 'ID')).toBe('ID must be a valid UUID');
+    expect(validateUuid('12345', 'ID')).toBe('ID must be a valid UUID');
+  });
+
+  it('accepts valid UUIDs', () => {
+    expect(validateUuid('550e8400-e29b-41d4-a716-446655440000', 'ID')).toBeNull();
+    expect(validateUuid('A550E840-E29B-41D4-A716-446655440000', 'ID')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Middleware: createValidator
+// ---------------------------------------------------------------------------
+
+describe('createValidator', () => {
+  it('calls next() with no error when all rules pass', () => {
+    const middleware = createValidator([
+      { field: 'email', required: true, type: 'email' },
+    ]);
+    const next = vi.fn();
+    middleware(mockReq({ email: 'user@example.com' }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('calls next(ValidationError) when a required field is missing', () => {
+    const middleware = createValidator([
+      { field: 'name', required: true, type: 'string' },
+    ]);
+    const next = vi.fn();
+    middleware(mockReq({}), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    expect((next.mock.calls[0][0] as ValidationError).message).toBe('Name is required');
+  });
+
+  it('normalizes email to lowercase and trims whitespace on req.body', () => {
+    const middleware = createValidator([
+      { field: 'email', required: true, type: 'email' },
+    ]);
+    const req = mockReq({ email: '  User@Example.COM  ' });
+    const next = vi.fn();
+    middleware(req, mockRes(), next);
+    expect(req.body.email).toBe('user@example.com');
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('validates string type with maxLength', () => {
+    const middleware = createValidator([
+      { field: 'name', required: true, type: 'string', maxLength: 5 },
+    ]);
+    const next = vi.fn();
+    middleware(mockReq({ name: 'toolong' }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    expect((next.mock.calls[0][0] as ValidationError).message).toBe(
+      'Name must not exceed 5 characters',
+    );
+  });
+
+  it('rejects non-string values for string type', () => {
+    const middleware = createValidator([
+      { field: 'name', required: true, type: 'string' },
+    ]);
+    const next = vi.fn();
+    middleware(mockReq({ name: 123 }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    expect((next.mock.calls[0][0] as ValidationError).message).toBe(
+      'Name must be a string',
+    );
+  });
+
+  it('skips optional fields that are absent', () => {
+    const middleware = createValidator([
+      { field: 'nickname', required: false, type: 'string' },
+    ]);
+    const next = vi.fn();
+    middleware(mockReq({}), mockRes(), next);
+    expect(next).toHaveBeenCalledWith();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-built middleware: validateRegistration
+// ---------------------------------------------------------------------------
+
+describe('validateRegistration', () => {
+  it('passes with valid email and password', () => {
+    const next = vi.fn();
+    validateRegistration(
+      mockReq({ email: 'user@example.com', password: 'securepass' }),
+      mockRes(),
+      next,
+    );
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('rejects missing email', () => {
+    const next = vi.fn();
+    validateRegistration(mockReq({ password: 'securepass' }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+  });
+
+  it('rejects missing password', () => {
+    const next = vi.fn();
+    validateRegistration(mockReq({ email: 'user@example.com' }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+  });
+
+  it('rejects short password', () => {
+    const next = vi.fn();
+    validateRegistration(
+      mockReq({ email: 'user@example.com', password: 'short' }),
+      mockRes(),
+      next,
+    );
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    expect((next.mock.calls[0][0] as ValidationError).message).toBe(
+      'Password must be at least 8 characters',
+    );
+  });
+
+  it('rejects password exceeding 128 chars', () => {
+    const next = vi.fn();
+    validateRegistration(
+      mockReq({ email: 'user@example.com', password: 'a'.repeat(129) }),
+      mockRes(),
+      next,
+    );
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    expect((next.mock.calls[0][0] as ValidationError).message).toBe(
+      'Password must not exceed 128 characters',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-built middleware: validateLogin
+// ---------------------------------------------------------------------------
+
+describe('validateLogin', () => {
+  it('passes with valid email and password (no length enforcement)', () => {
+    const next = vi.fn();
+    validateLogin(
+      mockReq({ email: 'user@example.com', password: 'pw' }),
+      mockRes(),
+      next,
+    );
+    // Login does not enforce password length — only presence
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('rejects missing email', () => {
+    const next = vi.fn();
+    validateLogin(mockReq({ password: 'pw' }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+  });
+
+  it('rejects missing password', () => {
+    const next = vi.fn();
+    validateLogin(mockReq({ email: 'user@example.com' }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pre-built middleware: validateSessionId
+// ---------------------------------------------------------------------------
+
+describe('validateSessionId', () => {
+  it('passes with a valid UUID param', () => {
+    const next = vi.fn();
+    validateSessionId(
+      mockReq({}, { sessionId: '550e8400-e29b-41d4-a716-446655440000' }),
+      mockRes(),
+      next,
+    );
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('rejects an invalid UUID param', () => {
+    const next = vi.fn();
+    validateSessionId(mockReq({}, { sessionId: 'bad' }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+    expect((next.mock.calls[0][0] as ValidationError).message).toBe(
+      'Session ID must be a valid UUID',
+    );
+  });
+
+  it('rejects a missing sessionId param', () => {
+    const next = vi.fn();
+    validateSessionId(mockReq({}, {}), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.any(ValidationError));
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/validator.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/middleware/validator.ts
@@ -1,0 +1,246 @@
+// ---------------------------------------------------------------------------
+// Request Validation Middleware
+// ---------------------------------------------------------------------------
+//
+// Validates and sanitizes incoming request payloads before they reach service
+// logic. Each middleware function checks the relevant fields and calls
+// `next(error)` with a `ValidationError` on the first violation, letting the
+// global error handler format the response.
+//
+// Email addresses are trimmed and lowercased *in place* on `req.body` so that
+// downstream code always receives the normalized value.
+// ---------------------------------------------------------------------------
+
+import { Request, Response, NextFunction } from 'express';
+import { ValidationError } from '../utils/errors';
+import { ValidationRule } from '../types';
+
+// ---------------------------------------------------------------------------
+// Core validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates an email string and returns a descriptive error message, or
+ * `null` when the value is acceptable.
+ *
+ * Rules applied (Requirements 1.5, 10.3, 10.4):
+ *  - Must be present (non-empty after trimming)
+ *  - Must contain exactly one `@` with non-empty local and domain parts
+ *  - Domain must contain at least one `.`
+ *  - Must not exceed 254 characters (RFC 5321 path limit)
+ */
+function validateEmail(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    return 'Email is required';
+  }
+
+  const trimmed = value.trim().toLowerCase();
+
+  if (trimmed.length > 254) {
+    return 'Email must not exceed 254 characters';
+  }
+
+  // Split on `@` — there must be exactly one, with content on both sides
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex < 1 || atIndex === trimmed.length - 1) {
+    return 'Email format is invalid';
+  }
+
+  // Ensure there is no second `@`
+  if (trimmed.indexOf('@', atIndex + 1) !== -1) {
+    return 'Email format is invalid';
+  }
+
+  const domain = trimmed.slice(atIndex + 1);
+
+  // Domain must contain at least one dot (e.g. "example.com")
+  if (!domain.includes('.')) {
+    return 'Email format is invalid';
+  }
+
+  // Domain must not end with a dot
+  if (domain.endsWith('.')) {
+    return 'Email format is invalid';
+  }
+
+  return null;
+}
+
+/**
+ * Validates a password string against length constraints.
+ *
+ * Rules applied (Requirements 1.6, 10.2):
+ *  - Must be present
+ *  - Minimum 8 characters
+ *  - Maximum 128 characters
+ */
+function validatePassword(value: unknown, requireLength = true): string | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return 'Password is required';
+  }
+
+  if (requireLength) {
+    if (value.length < 8) {
+      return 'Password must be at least 8 characters';
+    }
+
+    if (value.length > 128) {
+      return 'Password must not exceed 128 characters';
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Validates that a string is a well-formed UUID (v4-style hex with dashes).
+ */
+function validateUuid(value: unknown, fieldName: string): string | null {
+  if (typeof value !== 'string' || value.length === 0) {
+    return `${fieldName} is required`;
+  }
+
+  const uuidRegex =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+  if (!uuidRegex.test(value)) {
+    return `${fieldName} must be a valid UUID`;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Middleware factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an Express middleware that validates `req.body` against the
+ * supplied set of `ValidationRule`s.
+ *
+ * For email fields the value is trimmed and lowercased directly on
+ * `req.body` so that all downstream handlers receive the clean value.
+ */
+export function createValidator(rules: ValidationRule[]) {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    for (const rule of rules) {
+      const value = req.body?.[rule.field];
+
+      // --- required check (Requirement 10.1) ---
+      if (rule.required && (value === undefined || value === null || value === '')) {
+        return next(new ValidationError(`${capitalize(rule.field)} is required`));
+      }
+
+      // Skip further checks when the optional field is absent
+      if (value === undefined || value === null) {
+        continue;
+      }
+
+      // --- type-specific checks ---
+      switch (rule.type) {
+        case 'email': {
+          // Normalize in place before validation (Requirements 10.3, 10.4)
+          if (typeof value === 'string') {
+            req.body[rule.field] = value.trim().toLowerCase();
+          }
+          const emailError = validateEmail(value);
+          if (emailError) {
+            return next(new ValidationError(emailError));
+          }
+          break;
+        }
+
+        case 'password': {
+          // For login we only require presence; for registration we also
+          // enforce length constraints.
+          const passwordError = validatePassword(value, rule.maxLength !== undefined);
+          if (passwordError) {
+            return next(new ValidationError(passwordError));
+          }
+          break;
+        }
+
+        case 'uuid': {
+          const uuidError = validateUuid(value, capitalize(rule.field));
+          if (uuidError) {
+            return next(new ValidationError(uuidError));
+          }
+          break;
+        }
+
+        case 'string': {
+          if (typeof value !== 'string') {
+            return next(
+              new ValidationError(`${capitalize(rule.field)} must be a string`),
+            );
+          }
+          if (rule.maxLength && value.length > rule.maxLength) {
+            return next(
+              new ValidationError(
+                `${capitalize(rule.field)} must not exceed ${rule.maxLength} characters`,
+              ),
+            );
+          }
+          break;
+        }
+      }
+    }
+
+    next();
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pre-built middleware for common endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates the registration payload (Requirement 1.5, 1.6, 10.1–10.4).
+ *
+ * Rules:
+ *  - email:    required, valid format, max 254 chars, trimmed, lowercased
+ *  - password: required, min 8 chars, max 128 chars
+ */
+export const validateRegistration = createValidator([
+  { field: 'email', required: true, type: 'email', maxLength: 254 },
+  { field: 'password', required: true, type: 'password', maxLength: 128 },
+]);
+
+/**
+ * Validates the login payload.
+ *
+ * Rules:
+ *  - email:    required, valid format, trimmed, lowercased
+ *  - password: required (no length enforcement — the stored hash handles that)
+ */
+export const validateLogin = createValidator([
+  { field: 'email', required: true, type: 'email' },
+  { field: 'password', required: true, type: 'password' },
+]);
+
+/**
+ * Validates that a `:sessionId` path parameter is a valid UUID.
+ */
+export function validateSessionId(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const error = validateUuid(req.params.sessionId, 'Session ID');
+  if (error) {
+    return next(new ValidationError(error));
+  }
+  next();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capitalize the first letter of a string (used for error messages). */
+function capitalize(str: string): string {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+// Export individual validators for direct use in tests
+export { validateEmail, validatePassword, validateUuid };

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.test.ts
@@ -269,7 +269,7 @@ describe('sessionRepository', () => {
       expect(selectQuery!.params).toEqual(['hash-abc']);
     });
 
-    it('parses JSONB client_metadata from a string', async () => {
+    it('parses TEXT-encoded client_metadata from a JSON string', async () => {
       const now = new Date().toISOString();
       const client = createMockClient({
         defaultRows: [
@@ -382,23 +382,55 @@ describe('sessionRepository', () => {
   });
 
   // -----------------------------------------------------------------------
-  // revokeById
+  // revokeByIdForUser
   // -----------------------------------------------------------------------
 
-  describe('revokeById', () => {
-    it('updates the session with a revoked_at timestamp', async () => {
+  describe('revokeByIdForUser', () => {
+    it('updates the session with a revoked_at timestamp scoped by both id and user_id', async () => {
       const client = createMockClient({ defaultRowCount: 1 });
       const pool = createMockPool(client);
       const repo = createSessionRepository(pool);
 
-      await repo.revokeById('session-1');
+      const result = await repo.revokeByIdForUser('user-1', 'session-1');
 
       const updateQuery = client.queries.find((q) =>
         q.sql.includes('UPDATE sessions'),
       );
       expect(updateQuery).toBeDefined();
       expect(updateQuery!.sql).toContain('SET revoked_at = NOW()');
-      expect(updateQuery!.params).toEqual(['session-1']);
+      // Critical: the WHERE clause must filter by BOTH id AND user_id so a
+      // user cannot revoke another user's session by guessing the id (IDOR).
+      expect(updateQuery!.sql).toContain('id = $1');
+      expect(updateQuery!.sql).toContain('user_id = $2');
+      expect(updateQuery!.params).toEqual(['session-1', 'user-1']);
+      expect(result).toBe(true);
+    });
+
+    it('returns false when the session id does not match the user (IDOR-prevention)', async () => {
+      // The UPDATE matches zero rows because the session belongs to
+      // someone else. The repository must surface this as `false` so the
+      // service can throw InvalidSessionError without leaking that the
+      // session does in fact exist.
+      const client = createMockClient({ defaultRowCount: 0 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const result = await repo.revokeByIdForUser(
+        'attacker-user',
+        'victim-session-id',
+      );
+
+      expect(result).toBe(false);
+    });
+
+    it('returns false when the session is already revoked', async () => {
+      const client = createMockClient({ defaultRowCount: 0 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const result = await repo.revokeByIdForUser('user-1', 'already-revoked');
+
+      expect(result).toBe(false);
     });
 
     it('only revokes sessions that are not already revoked', async () => {
@@ -406,7 +438,7 @@ describe('sessionRepository', () => {
       const pool = createMockPool(client);
       const repo = createSessionRepository(pool);
 
-      await repo.revokeById('session-1');
+      await repo.revokeByIdForUser('user-1', 'session-1');
 
       const updateQuery = client.queries.find((q) =>
         q.sql.includes('UPDATE sessions'),
@@ -419,7 +451,7 @@ describe('sessionRepository', () => {
       const pool = createMockPool(client);
       const repo = createSessionRepository(pool);
 
-      await repo.revokeById('session-1');
+      await repo.revokeByIdForUser('user-1', 'session-1');
 
       const sqls = client.queries.map((q) => q.sql);
       expect(sqls[0]).toBe('BEGIN');
@@ -437,7 +469,9 @@ describe('sessionRepository', () => {
       const pool = createMockPool(client);
       const repo = createSessionRepository(pool);
 
-      await expect(repo.revokeById('session-1')).rejects.toThrow('db error');
+      await expect(
+        repo.revokeByIdForUser('user-1', 'session-1'),
+      ).rejects.toThrow('db error');
 
       const sqls = client.queries.map((q) => q.sql);
       expect(sqls).toContain('ROLLBACK');
@@ -448,7 +482,7 @@ describe('sessionRepository', () => {
       const pool = createMockPool(client);
       const repo = createSessionRepository(pool);
 
-      await repo.revokeById('session-1');
+      await repo.revokeByIdForUser('user-1', 'session-1');
 
       expect(client.release).toHaveBeenCalledTimes(1);
     });

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.test.ts
@@ -1,0 +1,566 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createSessionRepository,
+  PoolLike,
+  ClientLike,
+} from './sessionRepository';
+import { InvalidSessionError } from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers — lightweight mock pool and client
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock client that records queries and returns configurable results.
+ *
+ * The `queryResponses` map allows different SQL patterns to return different
+ * results, which is essential for testing the referential integrity check
+ * (SELECT on users) followed by the INSERT on sessions.
+ */
+function createMockClient(options?: {
+  queryResponses?: Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>;
+  defaultRows?: Record<string, unknown>[];
+  defaultRowCount?: number;
+  onQuery?: (sql: string, params?: unknown[]) => void;
+}): ClientLike & { queries: { sql: string; params?: unknown[] }[] } {
+  const queries: { sql: string; params?: unknown[] }[] = [];
+  return {
+    queries,
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      options?.onQuery?.(sql, params);
+
+      // Check for pattern-based responses
+      if (options?.queryResponses) {
+        for (const [pattern, response] of options.queryResponses) {
+          if (sql.includes(pattern)) {
+            return response;
+          }
+        }
+      }
+
+      return {
+        rows: options?.defaultRows ?? [],
+        rowCount: options?.defaultRowCount ?? 0,
+      };
+    }),
+    release: vi.fn(),
+  };
+}
+
+/**
+ * Creates a mock pool that returns the provided client on every `connect()`.
+ */
+function createMockPool(client: ClientLike): PoolLike {
+  return {
+    connect: vi.fn(async () => client),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sessionRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // create
+  // -----------------------------------------------------------------------
+
+  describe('create', () => {
+    const validSession = {
+      id: 'session-uuid-1',
+      userId: 'user-uuid-1',
+      tokenHash: 'abc123hash',
+      expiresAt: new Date('2025-01-02T00:00:00Z'),
+      clientMetadata: { userAgent: 'TestBrowser/1.0', ipAddress: '127.0.0.1' },
+    };
+
+    it('inserts a session when the referenced user exists', async () => {
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      // User existence check returns a row
+      responses.set('SELECT id FROM users', { rows: [{ id: 'user-uuid-1' }] });
+      // INSERT succeeds
+      responses.set('INSERT INTO sessions', { rows: [], rowCount: 1 });
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await expect(repo.create(validSession)).resolves.toBeUndefined();
+    });
+
+    it('verifies user_id exists before inserting (application-level referential integrity)', async () => {
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      responses.set('SELECT id FROM users', { rows: [{ id: 'user-uuid-1' }] });
+      responses.set('INSERT INTO sessions', { rows: [], rowCount: 1 });
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.create(validSession);
+
+      // The user check query should appear before the INSERT
+      const userCheckIdx = client.queries.findIndex((q) =>
+        q.sql.includes('SELECT id FROM users'),
+      );
+      const insertIdx = client.queries.findIndex((q) =>
+        q.sql.includes('INSERT INTO sessions'),
+      );
+      expect(userCheckIdx).toBeGreaterThan(-1);
+      expect(insertIdx).toBeGreaterThan(userCheckIdx);
+    });
+
+    it('throws InvalidSessionError when user_id does not exist', async () => {
+      // User existence check returns no rows
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      responses.set('SELECT id FROM users', { rows: [] });
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await expect(repo.create(validSession)).rejects.toThrow(InvalidSessionError);
+    });
+
+    it('uses parameterized queries for the INSERT', async () => {
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      responses.set('SELECT id FROM users', { rows: [{ id: 'user-uuid-1' }] });
+      responses.set('INSERT INTO sessions', { rows: [], rowCount: 1 });
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.create(validSession);
+
+      const insertQuery = client.queries.find((q) =>
+        q.sql.includes('INSERT INTO sessions'),
+      );
+      expect(insertQuery).toBeDefined();
+      expect(insertQuery!.params).toEqual([
+        'session-uuid-1',
+        'user-uuid-1',
+        'abc123hash',
+        validSession.expiresAt,
+        JSON.stringify(validSession.clientMetadata),
+      ]);
+    });
+
+    it('wraps the operation in a transaction (BEGIN / COMMIT)', async () => {
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      responses.set('SELECT id FROM users', { rows: [{ id: 'user-uuid-1' }] });
+      responses.set('INSERT INTO sessions', { rows: [], rowCount: 1 });
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.create(validSession);
+
+      const sqls = client.queries.map((q) => q.sql);
+      expect(sqls[0]).toBe('BEGIN');
+      expect(sqls[sqls.length - 1]).toBe('COMMIT');
+    });
+
+    it('rolls back the transaction on error', async () => {
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      responses.set('SELECT id FROM users', { rows: [] }); // triggers InvalidSessionError
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await expect(repo.create(validSession)).rejects.toThrow();
+
+      const sqls = client.queries.map((q) => q.sql);
+      expect(sqls).toContain('ROLLBACK');
+    });
+
+    it('releases the client back to the pool on success', async () => {
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      responses.set('SELECT id FROM users', { rows: [{ id: 'user-uuid-1' }] });
+      responses.set('INSERT INTO sessions', { rows: [], rowCount: 1 });
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.create(validSession);
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the client back to the pool on error', async () => {
+      const responses = new Map<string, { rows: Record<string, unknown>[]; rowCount?: number }>();
+      responses.set('SELECT id FROM users', { rows: [] });
+
+      const client = createMockClient({ queryResponses: responses });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await expect(repo.create(validSession)).rejects.toThrow();
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findByTokenHash
+  // -----------------------------------------------------------------------
+
+  describe('findByTokenHash', () => {
+    it('returns the session when found', async () => {
+      const now = new Date().toISOString();
+      const expiresAt = new Date(Date.now() + 86400000).toISOString();
+      const client = createMockClient({
+        defaultRows: [
+          {
+            id: 'session-1',
+            userId: 'user-1',
+            tokenHash: 'hash123',
+            createdAt: now,
+            expiresAt,
+            revokedAt: null,
+            clientMetadata: { userAgent: 'Chrome' },
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const session = await repo.findByTokenHash('hash123');
+
+      expect(session).not.toBeNull();
+      expect(session!.id).toBe('session-1');
+      expect(session!.userId).toBe('user-1');
+      expect(session!.tokenHash).toBe('hash123');
+      expect(session!.createdAt).toBeInstanceOf(Date);
+      expect(session!.expiresAt).toBeInstanceOf(Date);
+      expect(session!.revokedAt).toBeNull();
+      expect(session!.clientMetadata).toEqual({ userAgent: 'Chrome' });
+    });
+
+    it('returns null when no session matches', async () => {
+      const client = createMockClient({ defaultRows: [] });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const session = await repo.findByTokenHash('nonexistent');
+
+      expect(session).toBeNull();
+    });
+
+    it('uses a parameterized query', async () => {
+      const client = createMockClient({ defaultRows: [] });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.findByTokenHash('hash-abc');
+
+      const selectQuery = client.queries.find((q) =>
+        q.sql.includes('SELECT'),
+      );
+      expect(selectQuery).toBeDefined();
+      expect(selectQuery!.params).toEqual(['hash-abc']);
+    });
+
+    it('parses JSONB client_metadata from a string', async () => {
+      const now = new Date().toISOString();
+      const client = createMockClient({
+        defaultRows: [
+          {
+            id: 'session-1',
+            userId: 'user-1',
+            tokenHash: 'hash123',
+            createdAt: now,
+            expiresAt: now,
+            revokedAt: null,
+            clientMetadata: '{"ipAddress":"10.0.0.1"}',
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const session = await repo.findByTokenHash('hash123');
+
+      expect(session!.clientMetadata).toEqual({ ipAddress: '10.0.0.1' });
+    });
+
+    it('releases the client back to the pool', async () => {
+      const client = createMockClient({ defaultRows: [] });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.findByTokenHash('hash-abc');
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findActiveByUserId
+  // -----------------------------------------------------------------------
+
+  describe('findActiveByUserId', () => {
+    it('returns active sessions for the user', async () => {
+      const now = new Date().toISOString();
+      const expiresAt = new Date(Date.now() + 86400000).toISOString();
+      const client = createMockClient({
+        defaultRows: [
+          {
+            id: 'session-1',
+            userId: 'user-1',
+            tokenHash: 'hash1',
+            createdAt: now,
+            expiresAt,
+            revokedAt: null,
+            clientMetadata: {},
+          },
+          {
+            id: 'session-2',
+            userId: 'user-1',
+            tokenHash: 'hash2',
+            createdAt: now,
+            expiresAt,
+            revokedAt: null,
+            clientMetadata: { userAgent: 'Firefox' },
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const sessions = await repo.findActiveByUserId('user-1');
+
+      expect(sessions).toHaveLength(2);
+      expect(sessions[0].id).toBe('session-1');
+      expect(sessions[1].id).toBe('session-2');
+    });
+
+    it('returns an empty array when no active sessions exist', async () => {
+      const client = createMockClient({ defaultRows: [] });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const sessions = await repo.findActiveByUserId('user-no-sessions');
+
+      expect(sessions).toEqual([]);
+    });
+
+    it('filters by user_id, non-revoked, and non-expired in the query', async () => {
+      const client = createMockClient({ defaultRows: [] });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.findActiveByUserId('user-1');
+
+      const selectQuery = client.queries.find((q) =>
+        q.sql.includes('SELECT'),
+      );
+      expect(selectQuery).toBeDefined();
+      expect(selectQuery!.sql).toContain('user_id = $1');
+      expect(selectQuery!.sql).toContain('revoked_at IS NULL');
+      expect(selectQuery!.sql).toContain('expires_at > NOW()');
+      expect(selectQuery!.params).toEqual(['user-1']);
+    });
+
+    it('releases the client back to the pool', async () => {
+      const client = createMockClient({ defaultRows: [] });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.findActiveByUserId('user-1');
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // revokeById
+  // -----------------------------------------------------------------------
+
+  describe('revokeById', () => {
+    it('updates the session with a revoked_at timestamp', async () => {
+      const client = createMockClient({ defaultRowCount: 1 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.revokeById('session-1');
+
+      const updateQuery = client.queries.find((q) =>
+        q.sql.includes('UPDATE sessions'),
+      );
+      expect(updateQuery).toBeDefined();
+      expect(updateQuery!.sql).toContain('SET revoked_at = NOW()');
+      expect(updateQuery!.params).toEqual(['session-1']);
+    });
+
+    it('only revokes sessions that are not already revoked', async () => {
+      const client = createMockClient({ defaultRowCount: 1 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.revokeById('session-1');
+
+      const updateQuery = client.queries.find((q) =>
+        q.sql.includes('UPDATE sessions'),
+      );
+      expect(updateQuery!.sql).toContain('revoked_at IS NULL');
+    });
+
+    it('wraps the operation in a transaction (BEGIN / COMMIT)', async () => {
+      const client = createMockClient({ defaultRowCount: 1 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.revokeById('session-1');
+
+      const sqls = client.queries.map((q) => q.sql);
+      expect(sqls[0]).toBe('BEGIN');
+      expect(sqls[sqls.length - 1]).toBe('COMMIT');
+    });
+
+    it('rolls back the transaction on error', async () => {
+      const client = createMockClient({
+        onQuery: (sql) => {
+          if (sql.includes('UPDATE')) {
+            throw new Error('db error');
+          }
+        },
+      });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await expect(repo.revokeById('session-1')).rejects.toThrow('db error');
+
+      const sqls = client.queries.map((q) => q.sql);
+      expect(sqls).toContain('ROLLBACK');
+    });
+
+    it('releases the client back to the pool', async () => {
+      const client = createMockClient({ defaultRowCount: 1 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.revokeById('session-1');
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // revokeAllByUserId
+  // -----------------------------------------------------------------------
+
+  describe('revokeAllByUserId', () => {
+    it('revokes all active sessions for a user', async () => {
+      const client = createMockClient({ defaultRowCount: 5 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const count = await repo.revokeAllByUserId('user-1');
+
+      expect(count).toBe(5);
+    });
+
+    it('supports the excludeSessionId parameter', async () => {
+      const client = createMockClient({ defaultRowCount: 4 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const count = await repo.revokeAllByUserId('user-1', 'keep-this-session');
+
+      expect(count).toBe(4);
+
+      const updateQuery = client.queries.find((q) =>
+        q.sql.includes('UPDATE sessions'),
+      );
+      expect(updateQuery).toBeDefined();
+      expect(updateQuery!.sql).toContain('id != $2');
+      expect(updateQuery!.params).toContain('keep-this-session');
+    });
+
+    it('uses a LIMIT to respect the 3,000-row transaction cap', async () => {
+      const client = createMockClient({ defaultRowCount: 100 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.revokeAllByUserId('user-1');
+
+      const updateQuery = client.queries.find((q) =>
+        q.sql.includes('UPDATE sessions'),
+      );
+      expect(updateQuery).toBeDefined();
+      expect(updateQuery!.sql).toContain('LIMIT');
+      // The LIMIT parameter should be 3000
+      expect(updateQuery!.params).toContain(3000);
+    });
+
+    it('batches revocations when rowCount equals the batch limit', async () => {
+      // First batch returns exactly 3000 (the limit), second batch returns less
+      let callCount = 0;
+      const client = createMockClient({
+        onQuery: () => {
+          // no-op — we override the return via queryResponses
+        },
+      });
+
+      // Override the query mock to return different rowCounts per batch
+      const originalQuery = client.query;
+      client.query = vi.fn(async (sql: string, params?: unknown[]) => {
+        const result = await originalQuery(sql, params);
+        if (sql.includes('UPDATE sessions')) {
+          callCount++;
+          return { rows: [], rowCount: callCount === 1 ? 3000 : 500 };
+        }
+        return result;
+      }) as typeof client.query;
+
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const count = await repo.revokeAllByUserId('user-1');
+
+      // Should have done 2 batches: 3000 + 500 = 3500
+      expect(count).toBe(3500);
+    });
+
+    it('returns 0 when no active sessions exist', async () => {
+      const client = createMockClient({ defaultRowCount: 0 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      const count = await repo.revokeAllByUserId('user-1');
+
+      expect(count).toBe(0);
+    });
+
+    it('wraps each batch in a transaction', async () => {
+      const client = createMockClient({ defaultRowCount: 5 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.revokeAllByUserId('user-1');
+
+      const sqls = client.queries.map((q) => q.sql);
+      expect(sqls.filter((s) => s === 'BEGIN')).toHaveLength(1);
+      expect(sqls.filter((s) => s === 'COMMIT')).toHaveLength(1);
+    });
+
+    it('releases the client back to the pool', async () => {
+      const client = createMockClient({ defaultRowCount: 5 });
+      const pool = createMockPool(client);
+      const repo = createSessionRepository(pool);
+
+      await repo.revokeAllByUserId('user-1');
+
+      expect(client.release).toHaveBeenCalled();
+    });
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
@@ -45,9 +45,12 @@ export interface PoolLike {
 
 /**
  * Minimal interface for a database client obtained from the pool.
+ *
+ * `rowCount` mirrors the `pg` driver's contract for DML statements. Tests
+ * and mocks must populate it for write operations.
  */
 export interface ClientLike {
-  query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount?: number }>;
   release(): void;
 }
 
@@ -130,7 +133,14 @@ export function createSessionRepository(pool: PoolLike) {
 
           await client.query('COMMIT');
         } catch (error: unknown) {
-          await client.query('ROLLBACK');
+          // Best-effort rollback. If ROLLBACK itself throws (e.g. dead
+          // connection), preserve the *original* error so the caller still
+          // sees the SQLSTATE that drove the failure.
+          try {
+            await client.query('ROLLBACK');
+          } catch {
+            // swallow — re-throwing the original error below is more useful
+          }
           throw error;
         } finally {
           client.release();
@@ -195,28 +205,49 @@ export function createSessionRepository(pool: PoolLike) {
     },
 
     /**
-     * Revoke a single session by setting its `revoked_at` timestamp.
+     * Revoke a single session for a specific user.
      *
-     * The write is wrapped in the OCC retry utility for transient
-     * serialization error handling.
+     * Authorization is enforced at the SQL layer: the WHERE clause filters
+     * by both `id` AND `user_id`, so a request to revoke a session that
+     * belongs to a different user matches zero rows and returns `false`.
+     * This prevents Insecure Direct Object Reference (IDOR) — an attacker
+     * who guesses or steals another user's session ID cannot revoke it.
+     *
+     * @param userId    - The authenticated user (used as an authorization filter).
+     * @param sessionId - The session to revoke.
+     * @returns `true` when a row was updated (session belonged to the user
+     *          and was active); `false` when nothing matched (wrong user,
+     *          unknown session ID, or already revoked).
      */
-    async revokeById(sessionId: string): Promise<void> {
-      await retryWithBackoff(async () => {
+    async revokeByIdForUser(
+      userId: string,
+      sessionId: string,
+    ): Promise<boolean> {
+      return retryWithBackoff(async () => {
         const client = await pool.connect();
         try {
           await client.query('BEGIN');
 
-          await client.query(
+          const result = await client.query(
             `UPDATE sessions
              SET revoked_at = NOW()
              WHERE id = $1
+               AND user_id = $2
                AND revoked_at IS NULL`,
-            [sessionId],
+            [sessionId, userId],
           );
 
           await client.query('COMMIT');
+
+          return getRowCount(result) > 0;
         } catch (error: unknown) {
-          await client.query('ROLLBACK');
+          // Best-effort rollback. Preserve the *original* error if ROLLBACK
+          // also throws (e.g. dead connection) so callers see the real cause.
+          try {
+            await client.query('ROLLBACK');
+          } catch {
+            // swallow — re-throwing the original error below is more useful
+          }
           throw error;
         } finally {
           client.release();
@@ -289,7 +320,13 @@ export function createSessionRepository(pool: PoolLike) {
             // Our mock interface returns it via rows.length or a rowCount prop.
             return getRowCount(result);
           } catch (error: unknown) {
-            await client.query('ROLLBACK');
+            // Best-effort rollback. Preserve the *original* error if
+            // ROLLBACK also throws.
+            try {
+              await client.query('ROLLBACK');
+            } catch {
+              // swallow — re-throwing the original error below is more useful
+            }
             throw error;
           } finally {
             client.release();
@@ -312,7 +349,9 @@ export function createSessionRepository(pool: PoolLike) {
  * Maps a raw database row to a typed `Session` object.
  *
  * Handles the conversion of timestamp strings to `Date` objects and parses
- * the JSONB `client_metadata` column.
+ * the `client_metadata` column. Note: `client_metadata` is a TEXT column
+ * (Aurora DSQL does not support JSONB at this time), so the value is
+ * stored as a JSON-encoded string.
  */
 function mapRowToSession(row: Record<string, unknown>): Session {
   return {
@@ -329,14 +368,23 @@ function mapRowToSession(row: Record<string, unknown>): Session {
 /**
  * Safely parses the `client_metadata` column value.
  *
- * PostgreSQL's `pg` driver may return JSONB columns as already-parsed objects
- * or as raw strings depending on configuration. This helper handles both.
+ * The column is TEXT (Aurora DSQL does not support JSONB), so the `pg`
+ * driver always returns a string. We accept both string and pre-parsed
+ * object shapes for robustness against future driver changes or test mocks.
+ *
+ * If the stored value is not valid JSON, log the error rather than
+ * silently returning an empty object — that way operators can detect
+ * corruption or out-of-band writers that bypass `JSON.stringify`.
  */
 function parseClientMetadata(value: unknown): ClientMetadata {
   if (typeof value === 'string') {
     try {
       return JSON.parse(value) as ClientMetadata;
-    } catch {
+    } catch (error) {
+      console.warn(
+        '[sessionRepository] failed to parse client_metadata; defaulting to {}',
+        { error: error instanceof Error ? error.message : String(error) },
+      );
       return {};
     }
   }
@@ -349,13 +397,16 @@ function parseClientMetadata(value: unknown): ClientMetadata {
 /**
  * Extracts the row count from a query result.
  *
- * The `pg` library includes a `rowCount` property on DML results. Our narrow
- * `ClientLike` interface doesn't expose it directly, so we check for it at
- * runtime and fall back to 0.
+ * The `pg` library always sets `rowCount` for DML statements. We treat a
+ * missing value as a programming error rather than silently returning 0,
+ * because callers (e.g. the batch-revoke loop) rely on the value to know
+ * when to stop iterating.
  */
 function getRowCount(result: { rows: Record<string, unknown>[]; rowCount?: number }): number {
   if (typeof result.rowCount === 'number') {
     return result.rowCount;
   }
-  return 0;
+  throw new Error(
+    'Database driver did not return rowCount on a DML result; cannot determine affected rows',
+  );
 }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
@@ -1,0 +1,361 @@
+// ---------------------------------------------------------------------------
+// Session Repository
+// ---------------------------------------------------------------------------
+//
+// Data-access layer for the `sessions` table. All queries use parameterized
+// statements to prevent SQL injection, and write operations are wrapped in
+// the OCC retry utility so transient serialization errors (SQLSTATE 40001)
+// are handled transparently.
+//
+// Because Aurora DSQL does not support foreign keys, this repository enforces
+// referential integrity at the application level — it verifies that the
+// referenced `user_id` exists in the `users` table before inserting a session.
+//
+// The repository accepts a pool-like interface rather than the concrete
+// `AuroraDSQLPool` class, making it straightforward to test with a
+// lightweight mock — no AWS credentials required.
+//
+// Requirements:
+//   9.2 — Sessions table schema
+//   9.3 — Application-level referential integrity (user_id → users.id)
+//   9.4 — Store hashed token, not plaintext
+//  11.5 — OCC retry logic for session write operations
+//  12.1 — No single transaction modifies more than 3,000 rows
+//  12.2 — Batch revocation into ≤3,000-row transactions
+// ---------------------------------------------------------------------------
+
+import { Session, ClientMetadata } from '../types';
+import { InvalidSessionError } from '../utils/errors';
+import { retryWithBackoff } from '../utils/retryWithBackoff';
+
+// ---------------------------------------------------------------------------
+// Pool / Client interfaces (narrow types for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for a connection pool.
+ *
+ * Mirrors the pattern used by the user repository — accepting a narrow type
+ * instead of the concrete `AuroraDSQLPool` keeps this module easy to
+ * unit-test with a simple mock.
+ */
+export interface PoolLike {
+  connect(): Promise<ClientLike>;
+}
+
+/**
+ * Minimal interface for a database client obtained from the pool.
+ */
+export interface ClientLike {
+  query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  release(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Aurora DSQL limits each DML transaction to 3,000 rows.
+ *
+ * When revoking all sessions for a user, we batch the UPDATE statements
+ * into transactions of at most this many rows.
+ */
+const DSQL_MAX_ROWS_PER_TRANSACTION = 3_000;
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Session Repository bound to the given connection pool.
+ *
+ * Usage:
+ * ```ts
+ * const repo = createSessionRepository(pool);
+ * await repo.create({ id, userId, tokenHash, expiresAt, clientMetadata });
+ * ```
+ *
+ * @param pool - A connection pool (or pool-like mock) that provides `connect()`.
+ */
+export function createSessionRepository(pool: PoolLike) {
+  return {
+    /**
+     * Insert a new session record into the `sessions` table.
+     *
+     * Before inserting, verifies that the referenced `user_id` exists in the
+     * `users` table (application-level referential integrity). The write is
+     * wrapped in the OCC retry utility so that transient serialization errors
+     * from Aurora DSQL are retried automatically.
+     *
+     * @throws {InvalidSessionError} If the `userId` does not exist in the users table.
+     */
+    async create(session: {
+      id: string;
+      userId: string;
+      tokenHash: string;
+      expiresAt: Date;
+      clientMetadata: ClientMetadata;
+    }): Promise<void> {
+      await retryWithBackoff(async () => {
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+
+          // Application-level referential integrity check (Requirement 9.3).
+          // Aurora DSQL does not support foreign keys, so we verify the
+          // referenced user exists before inserting the session.
+          const userCheck = await client.query(
+            'SELECT id FROM users WHERE id = $1',
+            [session.userId],
+          );
+
+          if (userCheck.rows.length === 0) {
+            throw new InvalidSessionError(
+              `User with id ${session.userId} does not exist`,
+            );
+          }
+
+          await client.query(
+            `INSERT INTO sessions (id, user_id, token_hash, created_at, expires_at, revoked_at, client_metadata)
+             VALUES ($1, $2, $3, NOW(), $4, NULL, $5)`,
+            [
+              session.id,
+              session.userId,
+              session.tokenHash,
+              session.expiresAt,
+              JSON.stringify(session.clientMetadata),
+            ],
+          );
+
+          await client.query('COMMIT');
+        } catch (error: unknown) {
+          await client.query('ROLLBACK');
+          throw error;
+        } finally {
+          client.release();
+        }
+      });
+    },
+
+    /**
+     * Look up a session by its token hash.
+     *
+     * Returns the full session record including revocation status, so the
+     * caller (Session Service) can distinguish between expired, revoked,
+     * and active sessions.
+     *
+     * @returns The matching `Session`, or `null` if no session has that token hash.
+     */
+    async findByTokenHash(tokenHash: string): Promise<Session | null> {
+      const client = await pool.connect();
+      try {
+        const result = await client.query(
+          `SELECT id, user_id AS "userId", token_hash AS "tokenHash",
+                  created_at AS "createdAt", expires_at AS "expiresAt",
+                  revoked_at AS "revokedAt", client_metadata AS "clientMetadata"
+           FROM sessions
+           WHERE token_hash = $1`,
+          [tokenHash],
+        );
+
+        if (result.rows.length === 0) {
+          return null;
+        }
+
+        return mapRowToSession(result.rows[0]);
+      } finally {
+        client.release();
+      }
+    },
+
+    /**
+     * Retrieve all active (non-expired, non-revoked) sessions for a user.
+     *
+     * @returns An array of active `Session` records, possibly empty.
+     */
+    async findActiveByUserId(userId: string): Promise<Session[]> {
+      const client = await pool.connect();
+      try {
+        const result = await client.query(
+          `SELECT id, user_id AS "userId", token_hash AS "tokenHash",
+                  created_at AS "createdAt", expires_at AS "expiresAt",
+                  revoked_at AS "revokedAt", client_metadata AS "clientMetadata"
+           FROM sessions
+           WHERE user_id = $1
+             AND revoked_at IS NULL
+             AND expires_at > NOW()`,
+          [userId],
+        );
+
+        return result.rows.map(mapRowToSession);
+      } finally {
+        client.release();
+      }
+    },
+
+    /**
+     * Revoke a single session by setting its `revoked_at` timestamp.
+     *
+     * The write is wrapped in the OCC retry utility for transient
+     * serialization error handling.
+     */
+    async revokeById(sessionId: string): Promise<void> {
+      await retryWithBackoff(async () => {
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+
+          await client.query(
+            `UPDATE sessions
+             SET revoked_at = NOW()
+             WHERE id = $1
+               AND revoked_at IS NULL`,
+            [sessionId],
+          );
+
+          await client.query('COMMIT');
+        } catch (error: unknown) {
+          await client.query('ROLLBACK');
+          throw error;
+        } finally {
+          client.release();
+        }
+      });
+    },
+
+    /**
+     * Revoke all active sessions for a user, with optional exclusion.
+     *
+     * Respects Aurora DSQL's 3,000-row per-transaction limit by batching
+     * the revocation when the user has more active sessions than the limit.
+     *
+     * @param userId           - The user whose sessions should be revoked.
+     * @param excludeSessionId - Optional session ID to keep active (e.g. the current session).
+     * @returns The total number of sessions revoked across all batches.
+     */
+    async revokeAllByUserId(
+      userId: string,
+      excludeSessionId?: string,
+    ): Promise<number> {
+      let totalRevoked = 0;
+
+      // Keep revoking in batches until no more active sessions remain.
+      // Each batch runs in its own transaction to stay within the 3,000-row
+      // DSQL limit (Requirement 12.1, 12.2).
+      let batchRevoked: number;
+      do {
+        batchRevoked = await retryWithBackoff(async () => {
+          const client = await pool.connect();
+          try {
+            await client.query('BEGIN');
+
+            // Build the UPDATE with an optional exclusion clause.
+            // We use a sub-select with LIMIT to cap each transaction at
+            // DSQL_MAX_ROWS_PER_TRANSACTION rows.
+            let sql: string;
+            let params: unknown[];
+
+            if (excludeSessionId) {
+              sql = `UPDATE sessions
+                     SET revoked_at = NOW()
+                     WHERE id IN (
+                       SELECT id FROM sessions
+                       WHERE user_id = $1
+                         AND revoked_at IS NULL
+                         AND expires_at > NOW()
+                         AND id != $2
+                       LIMIT $3
+                     )`;
+              params = [userId, excludeSessionId, DSQL_MAX_ROWS_PER_TRANSACTION];
+            } else {
+              sql = `UPDATE sessions
+                     SET revoked_at = NOW()
+                     WHERE id IN (
+                       SELECT id FROM sessions
+                       WHERE user_id = $1
+                         AND revoked_at IS NULL
+                         AND expires_at > NOW()
+                       LIMIT $2
+                     )`;
+              params = [userId, DSQL_MAX_ROWS_PER_TRANSACTION];
+            }
+
+            const result = await client.query(sql, params);
+
+            await client.query('COMMIT');
+
+            // `pg` returns rowCount on the result object for DML statements.
+            // Our mock interface returns it via rows.length or a rowCount prop.
+            return getRowCount(result);
+          } catch (error: unknown) {
+            await client.query('ROLLBACK');
+            throw error;
+          } finally {
+            client.release();
+          }
+        });
+
+        totalRevoked += batchRevoked;
+      } while (batchRevoked === DSQL_MAX_ROWS_PER_TRANSACTION);
+
+      return totalRevoked;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps a raw database row to a typed `Session` object.
+ *
+ * Handles the conversion of timestamp strings to `Date` objects and parses
+ * the JSONB `client_metadata` column.
+ */
+function mapRowToSession(row: Record<string, unknown>): Session {
+  return {
+    id: row.id as string,
+    userId: row.userId as string,
+    tokenHash: row.tokenHash as string,
+    createdAt: new Date(row.createdAt as string),
+    expiresAt: new Date(row.expiresAt as string),
+    revokedAt: row.revokedAt ? new Date(row.revokedAt as string) : null,
+    clientMetadata: parseClientMetadata(row.clientMetadata),
+  };
+}
+
+/**
+ * Safely parses the `client_metadata` column value.
+ *
+ * PostgreSQL's `pg` driver may return JSONB columns as already-parsed objects
+ * or as raw strings depending on configuration. This helper handles both.
+ */
+function parseClientMetadata(value: unknown): ClientMetadata {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as ClientMetadata;
+    } catch {
+      return {};
+    }
+  }
+  if (typeof value === 'object' && value !== null) {
+    return value as ClientMetadata;
+  }
+  return {};
+}
+
+/**
+ * Extracts the row count from a query result.
+ *
+ * The `pg` library includes a `rowCount` property on DML results. Our narrow
+ * `ClientLike` interface doesn't expose it directly, so we check for it at
+ * runtime and fall back to 0.
+ */
+function getRowCount(result: { rows: Record<string, unknown>[]; rowCount?: number }): number {
+  if (typeof result.rowCount === 'number') {
+    return result.rowCount;
+  }
+  return 0;
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.test.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createUserRepository, PoolLike, ClientLike } from './userRepository';
+import { ConflictError } from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers — lightweight mock pool and client
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a mock client that records queries and returns configurable results.
+ */
+function createMockClient(options?: {
+  queryResults?: Record<string, unknown>[];
+  onQuery?: (sql: string, params?: unknown[]) => void;
+}): ClientLike & { queries: { sql: string; params?: unknown[] }[] } {
+  const queries: { sql: string; params?: unknown[] }[] = [];
+  return {
+    queries,
+    query: vi.fn(async (sql: string, params?: unknown[]) => {
+      queries.push({ sql, params });
+      options?.onQuery?.(sql, params);
+      return { rows: options?.queryResults ?? [] };
+    }),
+    release: vi.fn(),
+  };
+}
+
+/**
+ * Creates a mock pool that returns the provided client on every `connect()`.
+ */
+function createMockPool(client: ClientLike): PoolLike {
+  return {
+    connect: vi.fn(async () => client),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('userRepository', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // create
+  // -----------------------------------------------------------------------
+
+  describe('create', () => {
+    it('inserts a user and returns the created record', async () => {
+      const now = new Date().toISOString();
+      const client = createMockClient({
+        queryResults: [
+          {
+            id: 'test-uuid',
+            email: 'alice@example.com',
+            passwordHash: '$2b$10$hashedvalue',
+            createdAt: now,
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      const user = await repo.create({
+        id: 'test-uuid',
+        email: 'alice@example.com',
+        passwordHash: '$2b$10$hashedvalue',
+      });
+
+      expect(user.id).toBe('test-uuid');
+      expect(user.email).toBe('alice@example.com');
+      expect(user.passwordHash).toBe('$2b$10$hashedvalue');
+      expect(user.createdAt).toBeInstanceOf(Date);
+    });
+
+    it('uses parameterized queries for the INSERT', async () => {
+      const now = new Date().toISOString();
+      const client = createMockClient({
+        queryResults: [
+          {
+            id: 'uuid-1',
+            email: 'bob@example.com',
+            passwordHash: '$2b$10$hash',
+            createdAt: now,
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await repo.create({
+        id: 'uuid-1',
+        email: 'bob@example.com',
+        passwordHash: '$2b$10$hash',
+      });
+
+      // Find the INSERT query (skip BEGIN)
+      const insertQuery = client.queries.find((q) =>
+        q.sql.includes('INSERT INTO users'),
+      );
+      expect(insertQuery).toBeDefined();
+      expect(insertQuery!.params).toEqual([
+        'uuid-1',
+        'bob@example.com',
+        '$2b$10$hash',
+      ]);
+    });
+
+    it('wraps the INSERT in a transaction (BEGIN / COMMIT)', async () => {
+      const now = new Date().toISOString();
+      const client = createMockClient({
+        queryResults: [
+          {
+            id: 'uuid-1',
+            email: 'test@example.com',
+            passwordHash: '$2b$10$hash',
+            createdAt: now,
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await repo.create({
+        id: 'uuid-1',
+        email: 'test@example.com',
+        passwordHash: '$2b$10$hash',
+      });
+
+      const sqls = client.queries.map((q) => q.sql);
+      expect(sqls[0]).toBe('BEGIN');
+      expect(sqls[sqls.length - 1]).toBe('COMMIT');
+    });
+
+    it('throws ConflictError on duplicate email (unique violation 23505)', async () => {
+      const pgError = new Error('duplicate key value violates unique constraint');
+      (pgError as unknown as { code: string }).code = '23505';
+
+      const client = createMockClient({
+        onQuery: (sql) => {
+          if (sql.includes('INSERT')) {
+            throw pgError;
+          }
+        },
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await expect(
+        repo.create({
+          id: 'uuid-1',
+          email: 'dup@example.com',
+          passwordHash: '$2b$10$hash',
+        }),
+      ).rejects.toThrow(ConflictError);
+    });
+
+    it('rolls back the transaction on error', async () => {
+      const pgError = new Error('some db error');
+      (pgError as unknown as { code: string }).code = '23505';
+
+      const client = createMockClient({
+        onQuery: (sql) => {
+          if (sql.includes('INSERT')) {
+            throw pgError;
+          }
+        },
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await expect(
+        repo.create({
+          id: 'uuid-1',
+          email: 'fail@example.com',
+          passwordHash: '$2b$10$hash',
+        }),
+      ).rejects.toThrow();
+
+      const sqls = client.queries.map((q) => q.sql);
+      expect(sqls).toContain('ROLLBACK');
+    });
+
+    it('releases the client back to the pool on success', async () => {
+      const now = new Date().toISOString();
+      const client = createMockClient({
+        queryResults: [
+          {
+            id: 'uuid-1',
+            email: 'ok@example.com',
+            passwordHash: '$2b$10$hash',
+            createdAt: now,
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await repo.create({
+        id: 'uuid-1',
+        email: 'ok@example.com',
+        passwordHash: '$2b$10$hash',
+      });
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases the client back to the pool on error', async () => {
+      const pgError = new Error('unique violation');
+      (pgError as unknown as { code: string }).code = '23505';
+
+      const client = createMockClient({
+        onQuery: (sql) => {
+          if (sql.includes('INSERT')) {
+            throw pgError;
+          }
+        },
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await expect(
+        repo.create({
+          id: 'uuid-1',
+          email: 'fail@example.com',
+          passwordHash: '$2b$10$hash',
+        }),
+      ).rejects.toThrow();
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findByEmail
+  // -----------------------------------------------------------------------
+
+  describe('findByEmail', () => {
+    it('returns the user when found', async () => {
+      const now = new Date().toISOString();
+      const client = createMockClient({
+        queryResults: [
+          {
+            id: 'uuid-1',
+            email: 'alice@example.com',
+            passwordHash: '$2b$10$hash',
+            createdAt: now,
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      const user = await repo.findByEmail('alice@example.com');
+
+      expect(user).not.toBeNull();
+      expect(user!.id).toBe('uuid-1');
+      expect(user!.email).toBe('alice@example.com');
+      expect(user!.createdAt).toBeInstanceOf(Date);
+    });
+
+    it('returns null when no user matches', async () => {
+      const client = createMockClient({ queryResults: [] });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      const user = await repo.findByEmail('nobody@example.com');
+
+      expect(user).toBeNull();
+    });
+
+    it('uses a parameterized query', async () => {
+      const client = createMockClient({ queryResults: [] });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await repo.findByEmail('test@example.com');
+
+      const selectQuery = client.queries.find((q) =>
+        q.sql.includes('SELECT'),
+      );
+      expect(selectQuery).toBeDefined();
+      expect(selectQuery!.params).toEqual(['test@example.com']);
+    });
+
+    it('releases the client back to the pool', async () => {
+      const client = createMockClient({ queryResults: [] });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await repo.findByEmail('test@example.com');
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // findById
+  // -----------------------------------------------------------------------
+
+  describe('findById', () => {
+    it('returns the user when found', async () => {
+      const now = new Date().toISOString();
+      const client = createMockClient({
+        queryResults: [
+          {
+            id: 'uuid-1',
+            email: 'alice@example.com',
+            passwordHash: '$2b$10$hash',
+            createdAt: now,
+          },
+        ],
+      });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      const user = await repo.findById('uuid-1');
+
+      expect(user).not.toBeNull();
+      expect(user!.id).toBe('uuid-1');
+      expect(user!.email).toBe('alice@example.com');
+    });
+
+    it('returns null when no user matches', async () => {
+      const client = createMockClient({ queryResults: [] });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      const user = await repo.findById('nonexistent-uuid');
+
+      expect(user).toBeNull();
+    });
+
+    it('uses a parameterized query', async () => {
+      const client = createMockClient({ queryResults: [] });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await repo.findById('uuid-123');
+
+      const selectQuery = client.queries.find((q) =>
+        q.sql.includes('SELECT'),
+      );
+      expect(selectQuery).toBeDefined();
+      expect(selectQuery!.params).toEqual(['uuid-123']);
+    });
+
+    it('releases the client back to the pool', async () => {
+      const client = createMockClient({ queryResults: [] });
+      const pool = createMockPool(client);
+      const repo = createUserRepository(pool);
+
+      await repo.findById('uuid-123');
+
+      expect(client.release).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.ts
@@ -110,7 +110,14 @@ export function createUserRepository(pool: PoolLike) {
             createdAt: new Date(row.createdAt as string),
           };
         } catch (error: unknown) {
-          await client.query('ROLLBACK');
+          // Best-effort rollback. If ROLLBACK itself throws (e.g. dead
+          // connection), preserve the *original* error so we can still
+          // detect a unique-constraint violation and surface ConflictError.
+          try {
+            await client.query('ROLLBACK');
+          } catch {
+            // swallow — the original error below is more useful
+          }
 
           // Map PostgreSQL unique-violation on email to a friendly ConflictError
           if (isUniqueViolation(error)) {

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.ts
@@ -1,0 +1,208 @@
+// ---------------------------------------------------------------------------
+// User Repository
+// ---------------------------------------------------------------------------
+//
+// Data-access layer for the `users` table. All queries use parameterized
+// statements to prevent SQL injection, and write operations are wrapped in
+// the OCC retry utility so transient serialization errors (SQLSTATE 40001)
+// are handled transparently.
+//
+// The repository accepts a pool-like interface rather than the concrete
+// `AuroraDSQLPool` class, making it straightforward to test with a
+// lightweight mock — no AWS credentials required.
+//
+// Requirements:
+//   1.1 — Create user records in Aurora DSQL
+//   1.2 — Reject duplicate email registrations with a conflict error
+//   1.4 — Store id (UUID), email, password_hash, created_at
+//   9.1 — Users table schema
+//  12.5 — Generate UUIDs in the application layer
+// ---------------------------------------------------------------------------
+
+import { User } from '../types';
+import { ConflictError } from '../utils/errors';
+import { retryWithBackoff } from '../utils/retryWithBackoff';
+
+// ---------------------------------------------------------------------------
+// Pool / Client interfaces (narrow types for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for a connection pool.
+ *
+ * Mirrors the pattern used by the database migrator — accepting a narrow
+ * type instead of the concrete `AuroraDSQLPool` keeps this module easy to
+ * unit-test with a simple mock.
+ */
+export interface PoolLike {
+  connect(): Promise<ClientLike>;
+}
+
+/**
+ * Minimal interface for a database client obtained from the pool.
+ */
+export interface ClientLike {
+  query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  release(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * PostgreSQL error code for unique constraint violations.
+ *
+ * When an INSERT conflicts with a UNIQUE constraint (e.g. duplicate email),
+ * PostgreSQL raises error code `23505`.
+ */
+const UNIQUE_VIOLATION_CODE = '23505';
+
+// ---------------------------------------------------------------------------
+// Repository
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a User Repository bound to the given connection pool.
+ *
+ * Usage:
+ * ```ts
+ * const repo = createUserRepository(pool);
+ * const user = await repo.create({ id, email, passwordHash });
+ * ```
+ *
+ * @param pool - A connection pool (or pool-like mock) that provides `connect()`.
+ */
+export function createUserRepository(pool: PoolLike) {
+  return {
+    /**
+     * Insert a new user record into the `users` table.
+     *
+     * The write is wrapped in the OCC retry utility so that transient
+     * serialization errors from Aurora DSQL are retried automatically.
+     *
+     * @throws {ConflictError} If the email already exists (unique violation).
+     */
+    async create(user: {
+      id: string;
+      email: string;
+      passwordHash: string;
+    }): Promise<User> {
+      return retryWithBackoff(async () => {
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+
+          const result = await client.query(
+            `INSERT INTO users (id, email, password_hash, created_at)
+             VALUES ($1, $2, $3, NOW())
+             RETURNING id, email, password_hash AS "passwordHash", created_at AS "createdAt"`,
+            [user.id, user.email, user.passwordHash],
+          );
+
+          await client.query('COMMIT');
+
+          const row = result.rows[0];
+          return {
+            id: row.id as string,
+            email: row.email as string,
+            passwordHash: row.passwordHash as string,
+            createdAt: new Date(row.createdAt as string),
+          };
+        } catch (error: unknown) {
+          await client.query('ROLLBACK');
+
+          // Map PostgreSQL unique-violation on email to a friendly ConflictError
+          if (isUniqueViolation(error)) {
+            throw new ConflictError('Email already exists');
+          }
+
+          throw error;
+        } finally {
+          client.release();
+        }
+      });
+    },
+
+    /**
+     * Look up a user by their email address.
+     *
+     * @returns The matching `User`, or `null` if no user has that email.
+     */
+    async findByEmail(email: string): Promise<User | null> {
+      const client = await pool.connect();
+      try {
+        const result = await client.query(
+          `SELECT id, email, password_hash AS "passwordHash", created_at AS "createdAt"
+           FROM users
+           WHERE email = $1`,
+          [email],
+        );
+
+        if (result.rows.length === 0) {
+          return null;
+        }
+
+        const row = result.rows[0];
+        return {
+          id: row.id as string,
+          email: row.email as string,
+          passwordHash: row.passwordHash as string,
+          createdAt: new Date(row.createdAt as string),
+        };
+      } finally {
+        client.release();
+      }
+    },
+
+    /**
+     * Look up a user by their unique identifier.
+     *
+     * @returns The matching `User`, or `null` if no user has that id.
+     */
+    async findById(id: string): Promise<User | null> {
+      const client = await pool.connect();
+      try {
+        const result = await client.query(
+          `SELECT id, email, password_hash AS "passwordHash", created_at AS "createdAt"
+           FROM users
+           WHERE id = $1`,
+          [id],
+        );
+
+        if (result.rows.length === 0) {
+          return null;
+        }
+
+        const row = result.rows[0];
+        return {
+          id: row.id as string,
+          email: row.email as string,
+          passwordHash: row.passwordHash as string,
+          createdAt: new Date(row.createdAt as string),
+        };
+      } finally {
+        client.release();
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the error is a PostgreSQL unique constraint violation.
+ *
+ * The `pg` library attaches a `code` property to error objects that maps to
+ * the five-character SQLSTATE value. `23505` means "unique_violation".
+ */
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === UNIQUE_VIOLATION_CODE
+  );
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/authRoutes.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/authRoutes.test.ts
@@ -1,0 +1,238 @@
+// ---------------------------------------------------------------------------
+// Auth Routes — Unit Tests
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { createAuthRoutes, AuthServiceLike } from './authRoutes';
+import { errorHandler } from '../middleware/errorHandler';
+import { AuthenticatedRequest } from '../types';
+import {
+  ConflictError,
+  AuthenticationError,
+  ValidationError,
+} from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a test Express app with auth routes mounted at /api/auth.
+ *
+ * The auth middleware stub attaches a fixed user context so protected
+ * routes can be tested without real session validation.
+ */
+function buildApp(overrides?: Partial<AuthServiceLike>) {
+  const authService: AuthServiceLike = {
+    register: overrides?.register ??
+      vi.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'alice@example.com',
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      }),
+    login: overrides?.login ??
+      vi.fn().mockResolvedValue({
+        token: 'session-token-abc',
+        expiresAt: new Date('2025-01-02T00:00:00Z'),
+      }),
+    getProfile: overrides?.getProfile ??
+      vi.fn().mockResolvedValue({
+        id: 'user-1',
+        email: 'alice@example.com',
+        createdAt: new Date('2025-01-01T00:00:00Z'),
+      }),
+  };
+
+  // Stub auth middleware that attaches a fixed user context.
+  const authMiddleware = (req: Request, _res: Response, next: NextFunction) => {
+    const authReq = req as AuthenticatedRequest;
+    authReq.user = { id: 'user-1', email: 'alice@example.com' };
+    authReq.sessionId = 'session-1';
+    next();
+  };
+
+  const app = express();
+  app.use(express.json());
+
+  const router = createAuthRoutes({ authService, authMiddleware });
+  app.use('/api/auth', router);
+  app.use(errorHandler);
+
+  return { app, authService };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('POST /api/auth/register', () => {
+  it('returns 201 with user data on successful registration', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'alice@example.com', password: 'secureP@ss1' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      id: 'user-1',
+      email: 'alice@example.com',
+    });
+    expect(res.body.data.createdAt).toBeDefined();
+  });
+
+  it('calls authService.register with the provided email and password', async () => {
+    const { app, authService } = buildApp();
+
+    await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'bob@example.com', password: 'mypassword1' });
+
+    expect(authService.register).toHaveBeenCalledWith(
+      'bob@example.com',
+      'mypassword1',
+    );
+  });
+
+  it('returns 409 when email already exists', async () => {
+    const { app } = buildApp({
+      register: vi.fn().mockRejectedValue(new ConflictError()),
+    });
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'alice@example.com', password: 'secureP@ss1' });
+
+    expect(res.status).toBe(409);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('EMAIL_ALREADY_EXISTS');
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ password: 'secureP@ss1' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when password is too short', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/auth/register')
+      .send({ email: 'alice@example.com', password: 'short' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('POST /api/auth/login', () => {
+  it('returns 200 with token and expiry on successful login', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'alice@example.com', password: 'secureP@ss1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      token: 'session-token-abc',
+    });
+    expect(res.body.data.expiresAt).toBeDefined();
+  });
+
+  it('passes client metadata to authService.login', async () => {
+    const { app, authService } = buildApp();
+
+    await request(app)
+      .post('/api/auth/login')
+      .set('User-Agent', 'TestBrowser/1.0')
+      .send({ email: 'alice@example.com', password: 'secureP@ss1' });
+
+    expect(authService.login).toHaveBeenCalledWith(
+      'alice@example.com',
+      'secureP@ss1',
+      expect.objectContaining({
+        userAgent: 'TestBrowser/1.0',
+      }),
+    );
+  });
+
+  it('returns 401 with generic message for invalid credentials', async () => {
+    const { app } = buildApp({
+      login: vi.fn().mockRejectedValue(new AuthenticationError()),
+    });
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'alice@example.com', password: 'wrongpassword' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('AUTHENTICATION_FAILED');
+    expect(res.body.error.message).toBe('Invalid email or password');
+  });
+
+  it('returns 400 when email is missing', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ password: 'secureP@ss1' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when password is missing', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .post('/api/auth/login')
+      .send({ email: 'alice@example.com' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('GET /api/auth/me', () => {
+  it('returns 200 with user profile for authenticated requests', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toMatchObject({
+      id: 'user-1',
+      email: 'alice@example.com',
+    });
+    expect(res.body.data.createdAt).toBeDefined();
+  });
+
+  it('calls authService.getProfile with the authenticated user ID', async () => {
+    const { app, authService } = buildApp();
+
+    await request(app)
+      .get('/api/auth/me')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(authService.getProfile).toHaveBeenCalledWith('user-1');
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/authRoutes.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/authRoutes.ts
@@ -1,0 +1,164 @@
+// ---------------------------------------------------------------------------
+// Auth Routes
+// ---------------------------------------------------------------------------
+//
+// Defines the authentication-related HTTP endpoints:
+//
+//   POST /api/auth/register  — Create a new user account
+//   POST /api/auth/login     — Authenticate and receive a session token
+//   GET  /api/auth/me        — Retrieve the authenticated user's profile
+//
+// Dependencies (auth service, auth middleware, validators) are injected via
+// a factory function so the router is easy to test without a real database.
+//
+// All responses use the standard `ApiResponse<T>` envelope defined in
+// `src/types/index.ts`.
+//
+// Requirements:
+//   8.1 — POST /api/auth/register endpoint
+//   8.2 — POST /api/auth/login endpoint
+//   8.6 — GET /api/auth/me endpoint
+//   8.7 — Consistent JSON response structure
+// ---------------------------------------------------------------------------
+
+import { Router, Request, Response, NextFunction, RequestHandler } from 'express';
+import { AuthenticatedRequest, ApiResponse } from '../types';
+import { validateRegistration, validateLogin } from '../middleware/validator';
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces (narrow types for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for the Auth Service.
+ *
+ * Only the methods used by the route handlers are required, keeping the
+ * coupling surface small and tests lightweight.
+ */
+export interface AuthServiceLike {
+  register(
+    email: string,
+    password: string,
+  ): Promise<{ id: string; email: string; createdAt: Date }>;
+
+  login(
+    email: string,
+    password: string,
+    clientMetadata?: { userAgent?: string; ipAddress?: string },
+  ): Promise<{ token: string; expiresAt: Date }>;
+
+  getProfile(
+    userId: string,
+  ): Promise<{ id: string; email: string; createdAt: Date }>;
+}
+
+// ---------------------------------------------------------------------------
+// Auth Routes factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an Express router with authentication endpoints.
+ *
+ * @param deps.authService    - Service for registration, login, and profile.
+ * @param deps.authMiddleware - Middleware that validates the Bearer token and
+ *                              attaches `user` / `sessionId` to the request.
+ */
+export function createAuthRoutes(deps: {
+  authService: AuthServiceLike;
+  authMiddleware: RequestHandler;
+}): Router {
+  const { authService, authMiddleware } = deps;
+  const router = Router();
+
+  // -----------------------------------------------------------------------
+  // POST /api/auth/register
+  // -----------------------------------------------------------------------
+  // Validates the request body, creates a new user, and returns the public
+  // profile. Returns 201 on success (Requirement 8.1).
+  // -----------------------------------------------------------------------
+  router.post(
+    '/register',
+    validateRegistration,
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const { email, password } = req.body;
+
+        const user = await authService.register(email, password);
+
+        const body: ApiResponse<typeof user> = {
+          success: true,
+          data: user,
+        };
+
+        res.status(201).json(body);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // POST /api/auth/login
+  // -----------------------------------------------------------------------
+  // Validates credentials, authenticates the user, creates a session, and
+  // returns the session token with its expiry (Requirement 8.2).
+  //
+  // Client metadata (user agent, IP address) is extracted from the request
+  // and passed to the auth service for session creation.
+  // -----------------------------------------------------------------------
+  router.post(
+    '/login',
+    validateLogin,
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const { email, password } = req.body;
+
+        // Extract client metadata from the request for session tracking.
+        const clientMetadata = {
+          userAgent: req.headers['user-agent'] ?? undefined,
+          ipAddress: req.ip ?? undefined,
+        };
+
+        const session = await authService.login(email, password, clientMetadata);
+
+        const body: ApiResponse<typeof session> = {
+          success: true,
+          data: session,
+        };
+
+        res.status(200).json(body);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // GET /api/auth/me
+  // -----------------------------------------------------------------------
+  // Requires authentication. Returns the current user's profile
+  // (Requirement 8.6).
+  // -----------------------------------------------------------------------
+  router.get(
+    '/me',
+    authMiddleware,
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const { user } = req as AuthenticatedRequest;
+
+        const profile = await authService.getProfile(user.id);
+
+        const body: ApiResponse<typeof profile> = {
+          success: true,
+          data: profile,
+        };
+
+        res.status(200).json(body);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/sessionRoutes.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/sessionRoutes.test.ts
@@ -1,0 +1,194 @@
+// ---------------------------------------------------------------------------
+// Session Routes — Unit Tests
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi } from 'vitest';
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { createSessionRoutes, SessionServiceLike } from './sessionRoutes';
+import { errorHandler } from '../middleware/errorHandler';
+import { AuthenticatedRequest } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds a test Express app with session routes mounted at /api/sessions.
+ *
+ * The auth middleware stub attaches a fixed user context so all routes
+ * can be tested without real session validation.
+ */
+function buildApp(overrides?: Partial<SessionServiceLike>) {
+  const sessionService: SessionServiceLike = {
+    listSessions: overrides?.listSessions ??
+      vi.fn().mockResolvedValue([
+        {
+          id: 'session-1',
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+          expiresAt: new Date('2025-01-02T00:00:00Z'),
+          clientMetadata: { userAgent: 'TestBrowser/1.0' },
+        },
+        {
+          id: 'session-2',
+          createdAt: new Date('2025-01-01T12:00:00Z'),
+          expiresAt: new Date('2025-01-02T12:00:00Z'),
+          clientMetadata: {},
+        },
+      ]),
+    revokeSession: overrides?.revokeSession ?? vi.fn().mockResolvedValue(undefined),
+    revokeAllSessions: overrides?.revokeAllSessions ?? vi.fn().mockResolvedValue(undefined),
+  };
+
+  // Stub auth middleware that attaches a fixed user context.
+  const authMiddleware = (req: Request, _res: Response, next: NextFunction) => {
+    const authReq = req as AuthenticatedRequest;
+    authReq.user = { id: 'user-1', email: 'alice@example.com' };
+    authReq.sessionId = 'current-session-id';
+    next();
+  };
+
+  const app = express();
+  app.use(express.json());
+
+  const router = createSessionRoutes({ sessionService, authMiddleware });
+  app.use('/api/sessions', router);
+  app.use(errorHandler);
+
+  return { app, sessionService };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /api/sessions', () => {
+  it('returns 200 with a list of active sessions', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .get('/api/sessions')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(2);
+    expect(res.body.data[0]).toMatchObject({ id: 'session-1' });
+    expect(res.body.data[1]).toMatchObject({ id: 'session-2' });
+  });
+
+  it('calls sessionService.listSessions with the authenticated user ID', async () => {
+    const { app, sessionService } = buildApp();
+
+    await request(app)
+      .get('/api/sessions')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(sessionService.listSessions).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns 200 with empty array when user has no active sessions', async () => {
+    const { app } = buildApp({
+      listSessions: vi.fn().mockResolvedValue([]),
+    });
+
+    const res = await request(app)
+      .get('/api/sessions')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toEqual([]);
+  });
+});
+
+describe('DELETE /api/sessions/:sessionId', () => {
+  it('returns 200 on successful session revocation', async () => {
+    const { app } = buildApp();
+
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+    const res = await request(app)
+      .delete(`/api/sessions/${sessionId}`)
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.message).toBe('Session revoked');
+  });
+
+  it('calls sessionService.revokeSession with user ID and session ID', async () => {
+    const { app, sessionService } = buildApp();
+
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+    await request(app)
+      .delete(`/api/sessions/${sessionId}`)
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(sessionService.revokeSession).toHaveBeenCalledWith('user-1', sessionId);
+  });
+
+  it('returns 400 when session ID is not a valid UUID', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .delete('/api/sessions/not-a-uuid')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error.code).toBe('VALIDATION_ERROR');
+  });
+});
+
+describe('DELETE /api/sessions', () => {
+  it('returns 200 on successful revocation of all sessions', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app)
+      .delete('/api/sessions')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.message).toBe('All sessions revoked');
+  });
+
+  it('calls sessionService.revokeAllSessions without exclusion by default', async () => {
+    const { app, sessionService } = buildApp();
+
+    await request(app)
+      .delete('/api/sessions')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(sessionService.revokeAllSessions).toHaveBeenCalledWith(
+      'user-1',
+      undefined,
+    );
+  });
+
+  it('passes current session ID as exclusion when excludeCurrent=true', async () => {
+    const { app, sessionService } = buildApp();
+
+    await request(app)
+      .delete('/api/sessions?excludeCurrent=true')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(sessionService.revokeAllSessions).toHaveBeenCalledWith(
+      'user-1',
+      'current-session-id',
+    );
+  });
+
+  it('does not exclude current session when excludeCurrent is not "true"', async () => {
+    const { app, sessionService } = buildApp();
+
+    await request(app)
+      .delete('/api/sessions?excludeCurrent=false')
+      .set('Authorization', 'Bearer valid-token');
+
+    expect(sessionService.revokeAllSessions).toHaveBeenCalledWith(
+      'user-1',
+      undefined,
+    );
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/sessionRoutes.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/routes/sessionRoutes.ts
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------------
+// Session Routes
+// ---------------------------------------------------------------------------
+//
+// Defines the session management HTTP endpoints:
+//
+//   GET    /api/sessions              — List active sessions for the user
+//   DELETE /api/sessions/:sessionId   — Revoke a specific session
+//   DELETE /api/sessions              — Revoke all sessions (optionally
+//                                       excluding the current one)
+//
+// Dependencies (session service, auth middleware) are injected via a factory
+// function so the router is easy to test without a real database.
+//
+// All responses use the standard `ApiResponse<T>` envelope defined in
+// `src/types/index.ts`.
+//
+// Requirements:
+//   8.3 — GET /api/sessions endpoint
+//   8.4 — DELETE /api/sessions/:sessionId endpoint
+//   8.5 — DELETE /api/sessions endpoint (revoke all)
+//   8.7 — Consistent JSON response structure
+// ---------------------------------------------------------------------------
+
+import { Router, Request, Response, NextFunction, RequestHandler } from 'express';
+import { AuthenticatedRequest, ApiResponse, SessionInfo } from '../types';
+import { validateSessionId } from '../middleware/validator';
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces (narrow types for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for the Session Service.
+ *
+ * Only the methods used by the route handlers are required.
+ */
+export interface SessionServiceLike {
+  listSessions(userId: string): Promise<SessionInfo[]>;
+  revokeSession(userId: string, sessionId: string): Promise<void>;
+  revokeAllSessions(userId: string, excludeSessionId?: string): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Session Routes factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an Express router with session management endpoints.
+ *
+ * @param deps.sessionService - Service for listing and revoking sessions.
+ * @param deps.authMiddleware - Middleware that validates the Bearer token and
+ *                              attaches `user` / `sessionId` to the request.
+ */
+export function createSessionRoutes(deps: {
+  sessionService: SessionServiceLike;
+  authMiddleware: RequestHandler;
+}): Router {
+  const { sessionService, authMiddleware } = deps;
+  const router = Router();
+
+  // All session routes require authentication.
+  router.use(authMiddleware);
+
+  // -----------------------------------------------------------------------
+  // GET /api/sessions
+  // -----------------------------------------------------------------------
+  // Returns all active (non-expired, non-revoked) sessions for the
+  // authenticated user. Token hashes are never included in the response
+  // (Requirement 8.3).
+  // -----------------------------------------------------------------------
+  router.get(
+    '/',
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const { user } = req as AuthenticatedRequest;
+
+        const sessions = await sessionService.listSessions(user.id);
+
+        const body: ApiResponse<SessionInfo[]> = {
+          success: true,
+          data: sessions,
+        };
+
+        res.status(200).json(body);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // DELETE /api/sessions/:sessionId
+  // -----------------------------------------------------------------------
+  // Revokes a specific session by its UUID. The session ID is validated
+  // as a UUID before reaching the handler (Requirement 8.4).
+  // -----------------------------------------------------------------------
+  router.delete(
+    '/:sessionId',
+    validateSessionId,
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const { user } = req as AuthenticatedRequest;
+        const sessionId = req.params.sessionId as string;
+
+        await sessionService.revokeSession(user.id, sessionId);
+
+        const body: ApiResponse<{ message: string }> = {
+          success: true,
+          data: { message: 'Session revoked' },
+        };
+
+        res.status(200).json(body);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  // -----------------------------------------------------------------------
+  // DELETE /api/sessions
+  // -----------------------------------------------------------------------
+  // Revokes all sessions for the authenticated user. If the query parameter
+  // `excludeCurrent=true` is present, the current session (identified by
+  // `req.sessionId`) is preserved (Requirement 8.5, 6.4).
+  // -----------------------------------------------------------------------
+  router.delete(
+    '/',
+    async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      try {
+        const { user, sessionId } = req as AuthenticatedRequest;
+
+        // Check if the caller wants to keep the current session active.
+        const excludeCurrent = req.query.excludeCurrent === 'true';
+        const excludeSessionId = excludeCurrent ? sessionId : undefined;
+
+        await sessionService.revokeAllSessions(user.id, excludeSessionId);
+
+        const body: ApiResponse<{ message: string }> = {
+          success: true,
+          data: { message: 'All sessions revoked' },
+        };
+
+        res.status(200).json(body);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
+
+  return router;
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.test.ts
@@ -1,0 +1,263 @@
+// ---------------------------------------------------------------------------
+// Auth Service — Unit Tests
+// ---------------------------------------------------------------------------
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createAuthService, UserRepositoryLike, SessionServiceLike } from './authService';
+import { AuthenticationError, ConflictError } from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Helpers — lightweight stubs for dependencies
+// ---------------------------------------------------------------------------
+
+function createMockUserRepository(overrides: Partial<UserRepositoryLike> = {}): UserRepositoryLike {
+  return {
+    create: vi.fn(async (user) => ({
+      id: user.id,
+      email: user.email,
+      passwordHash: user.passwordHash,
+      createdAt: new Date('2025-01-01T00:00:00Z'),
+    })),
+    findByEmail: vi.fn(async () => null),
+    findById: vi.fn(async () => null),
+    ...overrides,
+  };
+}
+
+function createMockSessionService(overrides: Partial<SessionServiceLike> = {}): SessionServiceLike {
+  return {
+    createSession: vi.fn(async () => ({
+      token: 'mock-session-token',
+      expiresAt: new Date('2025-01-02T00:00:00Z'),
+    })),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AuthService', () => {
+  let userRepository: UserRepositoryLike;
+  let sessionService: SessionServiceLike;
+
+  beforeEach(() => {
+    userRepository = createMockUserRepository();
+    sessionService = createMockSessionService();
+  });
+
+  // -----------------------------------------------------------------------
+  // register
+  // -----------------------------------------------------------------------
+
+  describe('register', () => {
+    it('should create a user and return the public profile', async () => {
+      const authService = createAuthService({ userRepository, sessionService });
+
+      const result = await authService.register('alice@example.com', 'secureP@ss1');
+
+      // The returned profile should contain id, email, and createdAt
+      expect(result).toHaveProperty('id');
+      expect(result.email).toBe('alice@example.com');
+      expect(result.createdAt).toBeInstanceOf(Date);
+
+      // The repository should have been called with a UUID and a bcrypt hash
+      expect(userRepository.create).toHaveBeenCalledOnce();
+      const createArg = (userRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(createArg.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+      expect(createArg.email).toBe('alice@example.com');
+      // Password hash should be a bcrypt string, not the plaintext password
+      expect(createArg.passwordHash).toMatch(/^\$2[aby]\$/);
+    });
+
+    it('should not expose the password hash in the returned profile', async () => {
+      const authService = createAuthService({ userRepository, sessionService });
+
+      const result = await authService.register('bob@example.com', 'p@ssword123');
+
+      expect(result).not.toHaveProperty('passwordHash');
+      expect(result).not.toHaveProperty('password');
+    });
+
+    it('should propagate ConflictError for duplicate emails', async () => {
+      userRepository = createMockUserRepository({
+        create: vi.fn(async () => {
+          throw new ConflictError('Email already exists');
+        }),
+      });
+      const authService = createAuthService({ userRepository, sessionService });
+
+      await expect(authService.register('dup@example.com', 'p@ssword123')).rejects.toThrow(
+        ConflictError,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // login
+  // -----------------------------------------------------------------------
+
+  describe('login', () => {
+    it('should authenticate and return a session token for valid credentials', async () => {
+      // We need a real bcrypt hash for the mock user so `verify` works
+      const { hash } = await import('../utils/passwordHasher');
+      const passwordHash = await hash('correctPassword1');
+
+      userRepository = createMockUserRepository({
+        findByEmail: vi.fn(async () => ({
+          id: 'user-123',
+          email: 'alice@example.com',
+          passwordHash,
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        })),
+      });
+
+      const authService = createAuthService({ userRepository, sessionService });
+
+      const result = await authService.login('alice@example.com', 'correctPassword1');
+
+      expect(result.token).toBe('mock-session-token');
+      expect(result.expiresAt).toBeInstanceOf(Date);
+      expect(sessionService.createSession).toHaveBeenCalledWith('user-123', undefined);
+    });
+
+    it('should pass client metadata to the session service', async () => {
+      const { hash } = await import('../utils/passwordHasher');
+      const passwordHash = await hash('correctPassword1');
+
+      userRepository = createMockUserRepository({
+        findByEmail: vi.fn(async () => ({
+          id: 'user-123',
+          email: 'alice@example.com',
+          passwordHash,
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        })),
+      });
+
+      const authService = createAuthService({ userRepository, sessionService });
+      const metadata = { userAgent: 'TestAgent/1.0', ipAddress: '127.0.0.1' };
+
+      await authService.login('alice@example.com', 'correctPassword1', metadata);
+
+      expect(sessionService.createSession).toHaveBeenCalledWith('user-123', metadata);
+    });
+
+    it('should throw AuthenticationError when email is not found', async () => {
+      userRepository = createMockUserRepository({
+        findByEmail: vi.fn(async () => null),
+      });
+      const authService = createAuthService({ userRepository, sessionService });
+
+      await expect(
+        authService.login('unknown@example.com', 'anyPassword1'),
+      ).rejects.toThrow(AuthenticationError);
+    });
+
+    it('should throw AuthenticationError when password is incorrect', async () => {
+      const { hash } = await import('../utils/passwordHasher');
+      const passwordHash = await hash('correctPassword1');
+
+      userRepository = createMockUserRepository({
+        findByEmail: vi.fn(async () => ({
+          id: 'user-123',
+          email: 'alice@example.com',
+          passwordHash,
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        })),
+      });
+
+      const authService = createAuthService({ userRepository, sessionService });
+
+      await expect(
+        authService.login('alice@example.com', 'wrongPassword1'),
+      ).rejects.toThrow(AuthenticationError);
+    });
+
+    it('should use the same error message for email-not-found and wrong-password', async () => {
+      const { hash } = await import('../utils/passwordHasher');
+      const passwordHash = await hash('correctPassword1');
+
+      // Case 1: email not found
+      const repoNoUser = createMockUserRepository({
+        findByEmail: vi.fn(async () => null),
+      });
+      const serviceNoUser = createAuthService({
+        userRepository: repoNoUser,
+        sessionService,
+      });
+
+      let errorNoUser: AuthenticationError | undefined;
+      try {
+        await serviceNoUser.login('missing@example.com', 'anyPassword1');
+      } catch (e) {
+        errorNoUser = e as AuthenticationError;
+      }
+
+      // Case 2: wrong password
+      const repoWrongPw = createMockUserRepository({
+        findByEmail: vi.fn(async () => ({
+          id: 'user-123',
+          email: 'alice@example.com',
+          passwordHash,
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        })),
+      });
+      const serviceWrongPw = createAuthService({
+        userRepository: repoWrongPw,
+        sessionService,
+      });
+
+      let errorWrongPw: AuthenticationError | undefined;
+      try {
+        await serviceWrongPw.login('alice@example.com', 'wrongPassword1');
+      } catch (e) {
+        errorWrongPw = e as AuthenticationError;
+      }
+
+      // Both errors should have the same message (Requirement 2.4)
+      expect(errorNoUser).toBeInstanceOf(AuthenticationError);
+      expect(errorWrongPw).toBeInstanceOf(AuthenticationError);
+      expect(errorNoUser!.message).toBe(errorWrongPw!.message);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getProfile
+  // -----------------------------------------------------------------------
+
+  describe('getProfile', () => {
+    it('should return the public profile for an existing user', async () => {
+      userRepository = createMockUserRepository({
+        findById: vi.fn(async () => ({
+          id: 'user-123',
+          email: 'alice@example.com',
+          passwordHash: '$2a$10$somehash',
+          createdAt: new Date('2025-01-01T00:00:00Z'),
+        })),
+      });
+      const authService = createAuthService({ userRepository, sessionService });
+
+      const profile = await authService.getProfile('user-123');
+
+      expect(profile.id).toBe('user-123');
+      expect(profile.email).toBe('alice@example.com');
+      expect(profile.createdAt).toBeInstanceOf(Date);
+      // Must not leak the password hash
+      expect(profile).not.toHaveProperty('passwordHash');
+    });
+
+    it('should throw AuthenticationError when user is not found', async () => {
+      userRepository = createMockUserRepository({
+        findById: vi.fn(async () => null),
+      });
+      const authService = createAuthService({ userRepository, sessionService });
+
+      await expect(authService.getProfile('nonexistent-id')).rejects.toThrow(
+        AuthenticationError,
+      );
+    });
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.test.ts
@@ -156,6 +156,32 @@ describe('AuthService', () => {
       ).rejects.toThrow(AuthenticationError);
     });
 
+    it('runs dummyVerify in the no-user branch so login latency is independent of email existence (anti-enumeration)', async () => {
+      // Spy on bcrypt.compare to count calls. The timing-attack mitigation
+      // requires that the no-user branch perform the same bcrypt work as
+      // the wrong-password branch. We assert at least one bcrypt.compare
+      // happens before the AuthenticationError is thrown.
+      const bcrypt = (await import('bcryptjs')).default;
+      const compareSpy = vi.spyOn(bcrypt, 'compare');
+
+      userRepository = createMockUserRepository({
+        findByEmail: vi.fn(async () => null),
+      });
+      const authService = createAuthService({ userRepository, sessionService });
+
+      await expect(
+        authService.login('missing@example.com', 'whatever'),
+      ).rejects.toThrow(AuthenticationError);
+
+      // The dummyVerify path called bcrypt.compare once. Without the
+      // mitigation this spy would have zero calls when the user is
+      // missing, vs one call when the password is wrong — exactly the
+      // timing oracle the fix removes.
+      expect(compareSpy).toHaveBeenCalledTimes(1);
+
+      compareSpy.mockRestore();
+    });
+
     it('should throw AuthenticationError when password is incorrect', async () => {
       const { hash } = await import('../utils/passwordHasher');
       const passwordHash = await hash('correctPassword1');

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.ts
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------------------
+// Auth Service
+// ---------------------------------------------------------------------------
+//
+// Orchestrates user registration and login flows. This service sits between
+// the HTTP layer (routes / controllers) and the data-access layer
+// (repositories), coordinating password hashing, UUID generation, and
+// session creation.
+//
+// Dependencies are injected via the factory function so the service is easy
+// to test without a real database or AWS credentials.
+//
+// Security note: login returns the same generic error for both "email not
+// found" and "wrong password" to prevent user enumeration (Requirement 2.4).
+//
+// Requirements:
+//   1.1 — Create user records in Aurora DSQL
+//   2.1 — Authenticate user and delegate session creation
+//   2.2 — Reject login for non-existent email
+//   2.3 — Reject login for incorrect password
+//   2.4 — Same error message for email-not-found and wrong-password
+//   2.5 — Verify password against stored bcrypt hash
+// ---------------------------------------------------------------------------
+
+import crypto from 'node:crypto';
+import { User, ClientMetadata } from '../types';
+import { AuthenticationError } from '../utils/errors';
+import { hash, verify } from '../utils/passwordHasher';
+
+// ---------------------------------------------------------------------------
+// Dependency interfaces (narrow types for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for the User Repository.
+ *
+ * Mirrors the public surface of `createUserRepository` so the auth service
+ * can be tested with a lightweight stub.
+ */
+export interface UserRepositoryLike {
+  create(user: { id: string; email: string; passwordHash: string }): Promise<User>;
+  findByEmail(email: string): Promise<User | null>;
+  findById(id: string): Promise<User | null>;
+}
+
+/**
+ * Minimal interface for the Session Service.
+ *
+ * The session service is implemented separately (task 7.3). We depend only
+ * on the `createSession` method here so the auth service can delegate
+ * session creation during login.
+ */
+export interface SessionServiceLike {
+  createSession(
+    userId: string,
+    metadata?: ClientMetadata,
+  ): Promise<{ token: string; expiresAt: Date }>;
+}
+
+// ---------------------------------------------------------------------------
+// Auth Service factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates an Auth Service bound to the given dependencies.
+ *
+ * Usage:
+ * ```ts
+ * const authService = createAuthService({
+ *   userRepository,
+ *   sessionService,
+ * });
+ *
+ * const user = await authService.register('alice@example.com', 's3cureP@ss');
+ * const session = await authService.login('alice@example.com', 's3cureP@ss');
+ * ```
+ *
+ * @param deps.userRepository - Repository for user CRUD operations.
+ * @param deps.sessionService - Service for session lifecycle management.
+ */
+export function createAuthService(deps: {
+  userRepository: UserRepositoryLike;
+  sessionService: SessionServiceLike;
+}) {
+  const { userRepository, sessionService } = deps;
+
+  return {
+    /**
+     * Register a new user.
+     *
+     * Flow:
+     *   1. Hash the plaintext password with bcrypt (Requirement 1.3).
+     *   2. Generate a UUID for the new user (Requirement 12.5).
+     *   3. Insert the user record into the database (Requirement 1.1).
+     *   4. Return the public user profile (id, email, createdAt).
+     *
+     * Email uniqueness is enforced by the database's UNIQUE constraint on
+     * the `email` column. If a duplicate is detected, the user repository
+     * throws a `ConflictError` which propagates to the caller.
+     *
+     * @throws {ConflictError} If the email is already registered.
+     */
+    async register(
+      email: string,
+      password: string,
+    ): Promise<{ id: string; email: string; createdAt: Date }> {
+      // Step 1 — Hash the password in the application layer.
+      const passwordHash = await hash(password);
+
+      // Step 2 — Generate a UUID for the new user record.
+      const id = crypto.randomUUID();
+
+      // Step 3 — Persist the user. The repository handles OCC retries and
+      //          maps unique-constraint violations to ConflictError.
+      const user = await userRepository.create({ id, email, passwordHash });
+
+      // Step 4 — Return the public profile (never expose the password hash).
+      return {
+        id: user.id,
+        email: user.email,
+        createdAt: user.createdAt,
+      };
+    },
+
+    /**
+     * Authenticate a user and create a new session.
+     *
+     * Flow:
+     *   1. Look up the user by email (Requirement 2.2).
+     *   2. Verify the password against the stored hash (Requirement 2.5).
+     *   3. Delegate session creation to the Session Service (Requirement 2.1).
+     *   4. Return the session token and expiry.
+     *
+     * Both "email not found" and "wrong password" throw the same
+     * `AuthenticationError` with a generic message to prevent user
+     * enumeration (Requirement 2.4).
+     *
+     * @throws {AuthenticationError} If the email does not exist or the
+     *   password is incorrect.
+     */
+    async login(
+      email: string,
+      password: string,
+      clientMetadata?: ClientMetadata,
+    ): Promise<{ token: string; expiresAt: Date }> {
+      // Step 1 — Find the user by email.
+      const user = await userRepository.findByEmail(email);
+
+      if (!user) {
+        // Generic error — do not reveal that the email was not found.
+        throw new AuthenticationError();
+      }
+
+      // Step 2 — Verify the password against the stored bcrypt hash.
+      const isValid = await verify(password, user.passwordHash);
+
+      if (!isValid) {
+        // Generic error — do not reveal that the password was wrong.
+        throw new AuthenticationError();
+      }
+
+      // Step 3 — Create a session and return the token.
+      return sessionService.createSession(user.id, clientMetadata);
+    },
+
+    /**
+     * Retrieve a user's public profile by their identifier.
+     *
+     * @returns The user's id, email, and creation timestamp.
+     * @throws {AuthenticationError} If the user does not exist (e.g. deleted
+     *   after the session was created).
+     */
+    async getProfile(
+      userId: string,
+    ): Promise<{ id: string; email: string; createdAt: Date }> {
+      const user = await userRepository.findById(userId);
+
+      if (!user) {
+        throw new AuthenticationError('User not found');
+      }
+
+      return {
+        id: user.id,
+        email: user.email,
+        createdAt: user.createdAt,
+      };
+    },
+  };
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/authService.ts
@@ -25,7 +25,7 @@
 import crypto from 'node:crypto';
 import { User, ClientMetadata } from '../types';
 import { AuthenticationError } from '../utils/errors';
-import { hash, verify } from '../utils/passwordHasher';
+import { dummyVerify, hash, verify } from '../utils/passwordHasher';
 
 // ---------------------------------------------------------------------------
 // Dependency interfaces (narrow types for testability)
@@ -147,7 +147,12 @@ export function createAuthService(deps: {
       const user = await userRepository.findByEmail(email);
 
       if (!user) {
-        // Generic error — do not reveal that the email was not found.
+        // Run a dummy bcrypt verify so this branch takes the same time as
+        // the wrong-password branch below. Without this, an attacker could
+        // distinguish "email not registered" (~milliseconds) from "wrong
+        // password" (~80-100 ms at cost 10) via timing, even though both
+        // branches return the same generic error message.
+        await dummyVerify(password);
         throw new AuthenticationError();
       }
 

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.test.ts
@@ -1,0 +1,279 @@
+// ---------------------------------------------------------------------------
+// Session Service — Unit Tests
+// ---------------------------------------------------------------------------
+
+import crypto from 'node:crypto';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSessionService, SessionRepositoryLike } from './sessionService';
+import { InvalidSessionError, SessionExpiredError } from '../utils/errors';
+import { Session, ClientMetadata } from '../types';
+
+// ---------------------------------------------------------------------------
+// Helpers — lightweight stubs for the session repository
+// ---------------------------------------------------------------------------
+
+/** Builds a mock session repository with sensible defaults and optional overrides. */
+function createMockSessionRepository(
+  overrides: Partial<SessionRepositoryLike> = {},
+): SessionRepositoryLike {
+  return {
+    create: vi.fn(async () => {}),
+    findByTokenHash: vi.fn(async () => null),
+    findActiveByUserId: vi.fn(async () => []),
+    revokeById: vi.fn(async () => {}),
+    revokeAllByUserId: vi.fn(async () => 0),
+    ...overrides,
+  };
+}
+
+/** Creates a fake active session for testing. */
+function makeFakeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'session-1',
+    userId: 'user-1',
+    tokenHash: 'abc123hash',
+    createdAt: new Date('2025-01-01T00:00:00Z'),
+    expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000), // 24h from now
+    revokedAt: null,
+    clientMetadata: {},
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SessionService', () => {
+  let sessionRepository: SessionRepositoryLike;
+
+  beforeEach(() => {
+    sessionRepository = createMockSessionRepository();
+  });
+
+  // -----------------------------------------------------------------------
+  // createSession
+  // -----------------------------------------------------------------------
+
+  describe('createSession', () => {
+    it('should return a 64-character hex token and an expiration date', async () => {
+      const service = createSessionService({ sessionRepository });
+
+      const result = await service.createSession('user-1');
+
+      // Token must be a 64-char hex string (32 bytes encoded as hex).
+      expect(result.token).toMatch(/^[0-9a-f]{64}$/);
+      expect(result.expiresAt).toBeInstanceOf(Date);
+    });
+
+    it('should set expiration to approximately 24 hours from now', async () => {
+      const service = createSessionService({ sessionRepository });
+      const before = Date.now();
+
+      const result = await service.createSession('user-1');
+
+      const after = Date.now();
+      const twentyFourHoursMs = 24 * 60 * 60 * 1000;
+
+      // The expiry should be within a small tolerance of 24h from now.
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(before + twentyFourHoursMs);
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(after + twentyFourHoursMs);
+    });
+
+    it('should store the SHA-256 hash of the token, not the plaintext', async () => {
+      const service = createSessionService({ sessionRepository });
+
+      const result = await service.createSession('user-1');
+
+      // Verify the repository was called with the hash, not the plaintext.
+      const createCall = (sessionRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      const expectedHash = crypto
+        .createHash('sha256')
+        .update(result.token)
+        .digest('hex');
+
+      expect(createCall.tokenHash).toBe(expectedHash);
+      expect(createCall.tokenHash).not.toBe(result.token);
+    });
+
+    it('should generate a UUID for the session id', async () => {
+      const service = createSessionService({ sessionRepository });
+
+      await service.createSession('user-1');
+
+      const createCall = (sessionRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(createCall.id).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      );
+    });
+
+    it('should pass client metadata to the repository', async () => {
+      const service = createSessionService({ sessionRepository });
+      const metadata: ClientMetadata = { userAgent: 'TestAgent/1.0', ipAddress: '10.0.0.1' };
+
+      await service.createSession('user-1', metadata);
+
+      const createCall = (sessionRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(createCall.clientMetadata).toEqual(metadata);
+    });
+
+    it('should default client metadata to an empty object when not provided', async () => {
+      const service = createSessionService({ sessionRepository });
+
+      await service.createSession('user-1');
+
+      const createCall = (sessionRepository.create as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(createCall.clientMetadata).toEqual({});
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // validateSession
+  // -----------------------------------------------------------------------
+
+  describe('validateSession', () => {
+    it('should return userId and sessionId for a valid, active session', async () => {
+      const fakeSession = makeFakeSession();
+      // Compute the token hash that the service will look up.
+      const plainToken = 'a'.repeat(64);
+      const tokenHash = crypto.createHash('sha256').update(plainToken).digest('hex');
+      fakeSession.tokenHash = tokenHash;
+
+      sessionRepository = createMockSessionRepository({
+        findByTokenHash: vi.fn(async (hash: string) =>
+          hash === tokenHash ? fakeSession : null,
+        ),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      const result = await service.validateSession(plainToken);
+
+      expect(result.userId).toBe('user-1');
+      expect(result.sessionId).toBe('session-1');
+    });
+
+    it('should throw InvalidSessionError when no session matches the token', async () => {
+      sessionRepository = createMockSessionRepository({
+        findByTokenHash: vi.fn(async () => null),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      await expect(service.validateSession('nonexistent-token')).rejects.toThrow(
+        InvalidSessionError,
+      );
+    });
+
+    it('should throw InvalidSessionError when the session is revoked', async () => {
+      const revokedSession = makeFakeSession({
+        revokedAt: new Date('2025-01-01T12:00:00Z'),
+      });
+
+      sessionRepository = createMockSessionRepository({
+        findByTokenHash: vi.fn(async () => revokedSession),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      await expect(service.validateSession('some-token')).rejects.toThrow(
+        InvalidSessionError,
+      );
+    });
+
+    it('should throw SessionExpiredError when the session has expired', async () => {
+      const expiredSession = makeFakeSession({
+        expiresAt: new Date('2020-01-01T00:00:00Z'), // well in the past
+        revokedAt: null,
+      });
+
+      sessionRepository = createMockSessionRepository({
+        findByTokenHash: vi.fn(async () => expiredSession),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      await expect(service.validateSession('some-token')).rejects.toThrow(
+        SessionExpiredError,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // listSessions
+  // -----------------------------------------------------------------------
+
+  describe('listSessions', () => {
+    it('should return active sessions without the token hash', async () => {
+      const sessions: Session[] = [
+        makeFakeSession({ id: 's1', clientMetadata: { userAgent: 'Chrome' } }),
+        makeFakeSession({ id: 's2', clientMetadata: { ipAddress: '10.0.0.1' } }),
+      ];
+
+      sessionRepository = createMockSessionRepository({
+        findActiveByUserId: vi.fn(async () => sessions),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      const result = await service.listSessions('user-1');
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('s1');
+      expect(result[1].id).toBe('s2');
+
+      // Verify token hash is excluded from every entry.
+      for (const info of result) {
+        expect(info).not.toHaveProperty('tokenHash');
+        expect(info).toHaveProperty('createdAt');
+        expect(info).toHaveProperty('expiresAt');
+        expect(info).toHaveProperty('clientMetadata');
+      }
+    });
+
+    it('should return an empty array when the user has no active sessions', async () => {
+      sessionRepository = createMockSessionRepository({
+        findActiveByUserId: vi.fn(async () => []),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      const result = await service.listSessions('user-1');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // revokeSession
+  // -----------------------------------------------------------------------
+
+  describe('revokeSession', () => {
+    it('should delegate to the repository revokeById', async () => {
+      const service = createSessionService({ sessionRepository });
+
+      await service.revokeSession('user-1', 'session-42');
+
+      expect(sessionRepository.revokeById).toHaveBeenCalledWith('session-42');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // revokeAllSessions
+  // -----------------------------------------------------------------------
+
+  describe('revokeAllSessions', () => {
+    it('should delegate to the repository revokeAllByUserId', async () => {
+      const service = createSessionService({ sessionRepository });
+
+      await service.revokeAllSessions('user-1');
+
+      expect(sessionRepository.revokeAllByUserId).toHaveBeenCalledWith('user-1', undefined);
+    });
+
+    it('should pass the excludeSessionId when provided', async () => {
+      const service = createSessionService({ sessionRepository });
+
+      await service.revokeAllSessions('user-1', 'keep-this-session');
+
+      expect(sessionRepository.revokeAllByUserId).toHaveBeenCalledWith(
+        'user-1',
+        'keep-this-session',
+      );
+    });
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.test.ts
@@ -20,7 +20,7 @@ function createMockSessionRepository(
     create: vi.fn(async () => {}),
     findByTokenHash: vi.fn(async () => null),
     findActiveByUserId: vi.fn(async () => []),
-    revokeById: vi.fn(async () => {}),
+    revokeByIdForUser: vi.fn(async () => true),
     revokeAllByUserId: vi.fn(async () => 0),
     ...overrides,
   };
@@ -243,12 +243,48 @@ describe('SessionService', () => {
   // -----------------------------------------------------------------------
 
   describe('revokeSession', () => {
-    it('should delegate to the repository revokeById', async () => {
+    it('passes both userId and sessionId to revokeByIdForUser so the repository enforces ownership', async () => {
       const service = createSessionService({ sessionRepository });
 
       await service.revokeSession('user-1', 'session-42');
 
-      expect(sessionRepository.revokeById).toHaveBeenCalledWith('session-42');
+      // Assertion #1: ownership scope is forwarded to the repository call.
+      expect(sessionRepository.revokeByIdForUser).toHaveBeenCalledWith(
+        'user-1',
+        'session-42',
+      );
+    });
+
+    it('throws InvalidSessionError when the repository reports no row was updated (cross-user IDOR or unknown id)', async () => {
+      // Simulate the SQL-layer authorization filter rejecting the revoke:
+      // either the session ID does not exist, is already revoked, or
+      // belongs to a different user. The repository returns false; the
+      // service must surface this as InvalidSessionError so an attacker
+      // cannot distinguish the cases.
+      sessionRepository = createMockSessionRepository({
+        revokeByIdForUser: vi.fn(async () => false),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      await expect(
+        service.revokeSession('attacker-user', 'victim-session-id'),
+      ).rejects.toThrow(InvalidSessionError);
+
+      expect(sessionRepository.revokeByIdForUser).toHaveBeenCalledWith(
+        'attacker-user',
+        'victim-session-id',
+      );
+    });
+
+    it('does not throw when the repository confirms the row was updated', async () => {
+      sessionRepository = createMockSessionRepository({
+        revokeByIdForUser: vi.fn(async () => true),
+      });
+      const service = createSessionService({ sessionRepository });
+
+      await expect(
+        service.revokeSession('user-1', 'session-42'),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.ts
@@ -1,0 +1,247 @@
+// ---------------------------------------------------------------------------
+// Session Service
+// ---------------------------------------------------------------------------
+//
+// Manages the full session lifecycle: creation, validation, listing, and
+// revocation. This service sits between the HTTP layer and the Session
+// Repository, handling token generation, hashing, and expiration logic.
+//
+// Security model:
+//   - Tokens are generated with `crypto.randomBytes(32)` (256 bits of entropy)
+//     and encoded as 64-character hex strings.
+//   - Only the SHA-256 hash of the token is stored in the database. The
+//     plaintext token is returned to the caller exactly once at creation time.
+//   - Validation hashes the incoming token and queries for a matching hash
+//     that is neither expired nor revoked.
+//
+// Dependencies are injected via the factory function so the service is easy
+// to test without a real database or AWS credentials.
+//
+// Requirements:
+//   3.1 — Session record creation with all required fields
+//   3.2 — Cryptographically secure token generation (≥32 bytes)
+//   3.3 — 24-hour session expiration
+//   3.4 — Return token and expiry to caller
+//   4.1 — Query session by token
+//   4.2 — Validate active, non-expired session
+//   4.3 — Reject expired sessions
+//   4.4 — Reject non-existent sessions
+//   4.5 — Reject revoked sessions
+//   5.1 — List non-expired, non-revoked sessions
+//   5.2 — Include id, createdAt, expiresAt, clientMetadata in listing
+//   5.3 — Exclude token hash from listing
+//   6.1 — Revoke a specific session
+//   6.2 — Revoke all sessions for a user
+//   6.3 — Revoked sessions fail subsequent validation
+//   6.4 — Exclude current session from revoke-all
+// ---------------------------------------------------------------------------
+
+import crypto from 'node:crypto';
+import { Session, SessionInfo, ClientMetadata } from '../types';
+import { InvalidSessionError, SessionExpiredError } from '../utils/errors';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Session tokens are valid for 24 hours after creation. */
+const SESSION_DURATION_MS = 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Dependency interface (narrow type for testability)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal interface for the Session Repository.
+ *
+ * Mirrors the public surface of `createSessionRepository` so the session
+ * service can be tested with a lightweight stub — no database required.
+ */
+export interface SessionRepositoryLike {
+  create(session: {
+    id: string;
+    userId: string;
+    tokenHash: string;
+    expiresAt: Date;
+    clientMetadata: ClientMetadata;
+  }): Promise<void>;
+  findByTokenHash(tokenHash: string): Promise<Session | null>;
+  findActiveByUserId(userId: string): Promise<Session[]>;
+  revokeById(sessionId: string): Promise<void>;
+  revokeAllByUserId(userId: string, excludeSessionId?: string): Promise<number>;
+}
+
+// ---------------------------------------------------------------------------
+// Session Service factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a Session Service bound to the given Session Repository.
+ *
+ * Usage:
+ * ```ts
+ * const sessionService = createSessionService({ sessionRepository });
+ *
+ * const { token, expiresAt } = await sessionService.createSession(userId);
+ * const { userId, sessionId } = await sessionService.validateSession(token);
+ * ```
+ *
+ * @param deps.sessionRepository - Repository for session CRUD operations.
+ */
+export function createSessionService(deps: {
+  sessionRepository: SessionRepositoryLike;
+}) {
+  const { sessionRepository } = deps;
+
+  return {
+    /**
+     * Create a new session for the given user.
+     *
+     * Generates a cryptographically secure token, stores only its SHA-256
+     * hash in the database, and returns the plaintext token to the caller
+     * exactly once (Requirement 3.4).
+     *
+     * @param userId   - The authenticated user's identifier.
+     * @param metadata - Optional client metadata (user agent, IP address).
+     * @returns The plaintext session token and its expiration timestamp.
+     */
+    async createSession(
+      userId: string,
+      metadata?: ClientMetadata,
+    ): Promise<{ token: string; expiresAt: Date }> {
+      // Generate a 64-character hex token (32 bytes of entropy).
+      // Requirement 3.2 — cryptographically secure, ≥32 bytes.
+      const token = crypto.randomBytes(32).toString('hex');
+
+      // Hash the token with SHA-256 for storage (Requirement 9.4).
+      const tokenHash = hashToken(token);
+
+      // Generate a UUID for the session record (Requirement 12.5).
+      const id = crypto.randomUUID();
+
+      // Set expiration to 24 hours from now (Requirement 3.3).
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + SESSION_DURATION_MS);
+
+      // Persist the session — only the hash is stored, never the plaintext.
+      await sessionRepository.create({
+        id,
+        userId,
+        tokenHash,
+        expiresAt,
+        clientMetadata: metadata ?? {},
+      });
+
+      // Return the plaintext token exactly once (Requirement 3.4).
+      return { token, expiresAt };
+    },
+
+    /**
+     * Validate a session token and return the associated user context.
+     *
+     * Hashes the incoming token and queries for a matching record that is
+     * neither expired nor revoked.
+     *
+     * @param token - The plaintext session token from the Authorization header.
+     * @returns The user ID and session ID associated with the valid session.
+     *
+     * @throws {InvalidSessionError} If no session matches the token hash
+     *   (Requirement 4.4) or the session has been revoked (Requirement 4.5).
+     * @throws {SessionExpiredError} If the session has passed its expiration
+     *   timestamp (Requirement 4.3).
+     */
+    async validateSession(
+      token: string,
+    ): Promise<{ userId: string; sessionId: string }> {
+      // Hash the incoming token to look up the stored record.
+      const tokenHash = hashToken(token);
+
+      // Query for the session by its token hash (Requirement 4.1).
+      const session = await sessionRepository.findByTokenHash(tokenHash);
+
+      // No matching session found (Requirement 4.4).
+      if (!session) {
+        throw new InvalidSessionError();
+      }
+
+      // Session has been revoked (Requirement 4.5).
+      if (session.revokedAt !== null) {
+        throw new InvalidSessionError();
+      }
+
+      // Session has expired (Requirement 4.3).
+      if (session.expiresAt <= new Date()) {
+        throw new SessionExpiredError();
+      }
+
+      // Session is valid — return the user context (Requirement 4.2).
+      return { userId: session.userId, sessionId: session.id };
+    },
+
+    /**
+     * List all active sessions for a user.
+     *
+     * Returns only non-expired, non-revoked sessions. The token hash is
+     * intentionally excluded from the result to prevent token leakage
+     * (Requirement 5.3).
+     *
+     * @param userId - The user whose sessions to list.
+     * @returns An array of active session info objects.
+     */
+    async listSessions(userId: string): Promise<SessionInfo[]> {
+      // Fetch active sessions from the repository (Requirement 5.1).
+      const sessions = await sessionRepository.findActiveByUserId(userId);
+
+      // Map to SessionInfo, excluding the token hash (Requirement 5.2, 5.3).
+      return sessions.map((session) => ({
+        id: session.id,
+        createdAt: session.createdAt,
+        expiresAt: session.expiresAt,
+        clientMetadata: session.clientMetadata,
+      }));
+    },
+
+    /**
+     * Revoke a specific session.
+     *
+     * Marks the session as revoked so subsequent validation attempts for
+     * its token will be rejected (Requirement 6.1, 6.3).
+     *
+     * @param userId    - The authenticated user's identifier (for authorization).
+     * @param sessionId - The session to revoke.
+     */
+    async revokeSession(userId: string, sessionId: string): Promise<void> {
+      await sessionRepository.revokeById(sessionId);
+    },
+
+    /**
+     * Revoke all sessions for a user, with an optional exclusion.
+     *
+     * Useful for "log out everywhere" or "log out everywhere except here"
+     * flows (Requirement 6.2, 6.4).
+     *
+     * @param userId           - The user whose sessions to revoke.
+     * @param excludeSessionId - Optional session ID to keep active.
+     */
+    async revokeAllSessions(
+      userId: string,
+      excludeSessionId?: string,
+    ): Promise<void> {
+      await sessionRepository.revokeAllByUserId(userId, excludeSessionId);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the SHA-256 hash of a plaintext token.
+ *
+ * Used both at creation time (to store the hash) and at validation time
+ * (to look up the stored hash).
+ */
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/services/sessionService.ts
@@ -67,7 +67,14 @@ export interface SessionRepositoryLike {
   }): Promise<void>;
   findByTokenHash(tokenHash: string): Promise<Session | null>;
   findActiveByUserId(userId: string): Promise<Session[]>;
-  revokeById(sessionId: string): Promise<void>;
+  /**
+   * Revoke a session that belongs to a specific user. The repository's
+   * UPDATE is filtered by both `id` and `user_id`, returning `true` only
+   * when a row was actually updated. This is the authorization boundary
+   * for session revocation — a user passing another user's session ID
+   * matches zero rows and gets `false`.
+   */
+  revokeByIdForUser(userId: string, sessionId: string): Promise<boolean>;
   revokeAllByUserId(userId: string, excludeSessionId?: string): Promise<number>;
 }
 
@@ -202,16 +209,27 @@ export function createSessionService(deps: {
     },
 
     /**
-     * Revoke a specific session.
+     * Revoke a specific session that belongs to the given user.
      *
-     * Marks the session as revoked so subsequent validation attempts for
-     * its token will be rejected (Requirement 6.1, 6.3).
+     * The user ID is used as an authorization filter — the underlying
+     * repository UPDATE matches `WHERE id = $sessionId AND user_id = $userId`,
+     * so a request to revoke a session belonging to a different user
+     * matches zero rows and throws `InvalidSessionError`. This prevents
+     * Insecure Direct Object Reference (IDOR): an attacker who guesses or
+     * obtains another user's session ID cannot revoke it.
      *
-     * @param userId    - The authenticated user's identifier (for authorization).
+     * Requirements: 6.1, 6.3.
+     *
+     * @param userId    - The authenticated user (authorization scope).
      * @param sessionId - The session to revoke.
+     * @throws {InvalidSessionError} If the session does not exist, has
+     *   already been revoked, or belongs to a different user.
      */
     async revokeSession(userId: string, sessionId: string): Promise<void> {
-      await sessionRepository.revokeById(sessionId);
+      const revoked = await sessionRepository.revokeByIdForUser(userId, sessionId);
+      if (!revoked) {
+        throw new InvalidSessionError('Session not found');
+      }
     },
 
     /**

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/types/index.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/types/index.ts
@@ -1,0 +1,102 @@
+import { Request } from 'express';
+
+// ---------------------------------------------------------------------------
+// API Response Envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Standard response wrapper for all API endpoints.
+ *
+ * Every response — success or error — uses this envelope so clients can rely
+ * on a single, predictable shape.
+ *
+ * @template T - The type of the `data` payload on success.
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: { code: string; message: string };
+}
+
+// ---------------------------------------------------------------------------
+// Domain Models
+// ---------------------------------------------------------------------------
+
+/**
+ * A registered user stored in the `users` table.
+ *
+ * Passwords are never stored in plaintext — `passwordHash` holds the bcrypt
+ * output produced by the application-layer Password Hasher.
+ */
+export interface User {
+  id: string;
+  email: string;
+  passwordHash: string;
+  createdAt: Date;
+}
+
+/**
+ * A login session stored in the `sessions` table.
+ *
+ * `tokenHash` is the SHA-256 hash of the plaintext session token. The
+ * plaintext token is returned to the client exactly once at creation time
+ * and is never persisted.
+ */
+export interface Session {
+  id: string;
+  userId: string;
+  tokenHash: string;
+  createdAt: Date;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  clientMetadata: ClientMetadata;
+}
+
+/**
+ * Optional metadata captured at session creation time (user agent, IP, etc.).
+ */
+export interface ClientMetadata {
+  userAgent?: string;
+  ipAddress?: string;
+}
+
+/**
+ * Public session information returned by the listing endpoint.
+ *
+ * Intentionally omits `tokenHash` to prevent token leakage.
+ */
+export interface SessionInfo {
+  id: string;
+  createdAt: Date;
+  expiresAt: Date;
+  clientMetadata: ClientMetadata;
+}
+
+// ---------------------------------------------------------------------------
+// Express Extensions
+// ---------------------------------------------------------------------------
+
+/**
+ * Express `Request` augmented with the authenticated user context.
+ *
+ * The auth middleware attaches `user` and `sessionId` after validating the
+ * Bearer token in the `Authorization` header.
+ */
+export interface AuthenticatedRequest extends Request {
+  user: { id: string; email: string };
+  sessionId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Describes a single validation rule applied to an incoming request field.
+ */
+export interface ValidationRule {
+  field: string;
+  required: boolean;
+  type: 'email' | 'password' | 'uuid' | 'string';
+  maxLength?: number;
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/errors.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/errors.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AppError,
+  ValidationError,
+  AuthenticationError,
+  ConflictError,
+  SessionExpiredError,
+  InvalidSessionError,
+  ServiceUnavailableError,
+} from './errors';
+
+describe('Custom Error Classes', () => {
+  describe('ValidationError', () => {
+    it('should have status 400 and code VALIDATION_ERROR', () => {
+      const error = new ValidationError('Email is required');
+      expect(error.statusCode).toBe(400);
+      expect(error.code).toBe('VALIDATION_ERROR');
+      expect(error.message).toBe('Email is required');
+      expect(error.name).toBe('ValidationError');
+      expect(error).toBeInstanceOf(ValidationError);
+      expect(error).toBeInstanceOf(AppError);
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe('AuthenticationError', () => {
+    it('should have status 401 and code AUTHENTICATION_FAILED', () => {
+      const error = new AuthenticationError();
+      expect(error.statusCode).toBe(401);
+      expect(error.code).toBe('AUTHENTICATION_FAILED');
+      expect(error.message).toBe('Invalid email or password');
+    });
+
+    it('should accept a custom message', () => {
+      const error = new AuthenticationError('Custom auth message');
+      expect(error.message).toBe('Custom auth message');
+      expect(error.statusCode).toBe(401);
+    });
+  });
+
+  describe('ConflictError', () => {
+    it('should have status 409 and code EMAIL_ALREADY_EXISTS', () => {
+      const error = new ConflictError();
+      expect(error.statusCode).toBe(409);
+      expect(error.code).toBe('EMAIL_ALREADY_EXISTS');
+      expect(error.message).toBe('Email already exists');
+    });
+  });
+
+  describe('SessionExpiredError', () => {
+    it('should have status 401 and code INVALID_SESSION', () => {
+      const error = new SessionExpiredError();
+      expect(error.statusCode).toBe(401);
+      expect(error.code).toBe('INVALID_SESSION');
+      expect(error.message).toBe('Session has expired');
+    });
+  });
+
+  describe('InvalidSessionError', () => {
+    it('should have status 401 and code INVALID_SESSION', () => {
+      const error = new InvalidSessionError();
+      expect(error.statusCode).toBe(401);
+      expect(error.code).toBe('INVALID_SESSION');
+      expect(error.message).toBe('Invalid session');
+    });
+  });
+
+  describe('ServiceUnavailableError', () => {
+    it('should have status 503 and code SERVICE_UNAVAILABLE', () => {
+      const error = new ServiceUnavailableError();
+      expect(error.statusCode).toBe(503);
+      expect(error.code).toBe('SERVICE_UNAVAILABLE');
+      expect(error.message).toBe('Service temporarily unavailable');
+    });
+  });
+
+  describe('instanceof checks', () => {
+    it('all custom errors should be instances of AppError and Error', () => {
+      const errors = [
+        new ValidationError('test'),
+        new AuthenticationError(),
+        new ConflictError(),
+        new SessionExpiredError(),
+        new InvalidSessionError(),
+        new ServiceUnavailableError(),
+      ];
+
+      for (const error of errors) {
+        expect(error).toBeInstanceOf(AppError);
+        expect(error).toBeInstanceOf(Error);
+      }
+    });
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/errors.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/errors.ts
@@ -14,13 +14,22 @@
  *
  * Subclasses set `statusCode` and `code` so the global error handler can
  * build the correct `ApiResponse` without inspecting error messages.
+ *
+ * The optional `cause` (forwarded to `Error`'s standard ErrorOptions) lets
+ * callers attach an underlying error for forensic logging without exposing
+ * it to API clients.
  */
 export class AppError extends Error {
   public readonly statusCode: number;
   public readonly code: string;
 
-  constructor(message: string, statusCode: number, code: string) {
-    super(message);
+  constructor(
+    message: string,
+    statusCode: number,
+    code: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
     this.name = this.constructor.name;
     this.statusCode = statusCode;
     this.code = code;
@@ -82,7 +91,10 @@ export class InvalidSessionError extends AppError {
  * request from being fulfilled right now.
  */
 export class ServiceUnavailableError extends AppError {
-  constructor(message: string = 'Service temporarily unavailable') {
-    super(message, 503, 'SERVICE_UNAVAILABLE');
+  constructor(
+    message: string = 'Service temporarily unavailable',
+    options?: ErrorOptions,
+  ) {
+    super(message, 503, 'SERVICE_UNAVAILABLE', options);
   }
 }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/errors.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/errors.ts
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------
+// Custom Error Classes
+// ---------------------------------------------------------------------------
+//
+// Each error carries an HTTP status code and a machine-readable error code so
+// the global error handler can map them directly to the API response envelope
+// without a lookup table.
+//
+// Error categories are defined in the design document's Error Handling section.
+// ---------------------------------------------------------------------------
+
+/**
+ * Base class for all application-specific errors.
+ *
+ * Subclasses set `statusCode` and `code` so the global error handler can
+ * build the correct `ApiResponse` without inspecting error messages.
+ */
+export class AppError extends Error {
+  public readonly statusCode: number;
+  public readonly code: string;
+
+  constructor(message: string, statusCode: number, code: string) {
+    super(message);
+    this.name = this.constructor.name;
+    this.statusCode = statusCode;
+    this.code = code;
+
+    // Maintain proper prototype chain for instanceof checks
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * 400 — Request payload failed validation (missing fields, bad format, etc.).
+ */
+export class ValidationError extends AppError {
+  constructor(message: string) {
+    super(message, 400, 'VALIDATION_ERROR');
+  }
+}
+
+/**
+ * 401 — Credentials are invalid (wrong email or wrong password).
+ *
+ * The same generic message is used for both cases to prevent user enumeration.
+ */
+export class AuthenticationError extends AppError {
+  constructor(message: string = 'Invalid email or password') {
+    super(message, 401, 'AUTHENTICATION_FAILED');
+  }
+}
+
+/**
+ * 409 — A resource already exists (e.g. duplicate email registration).
+ */
+export class ConflictError extends AppError {
+  constructor(message: string = 'Email already exists') {
+    super(message, 409, 'EMAIL_ALREADY_EXISTS');
+  }
+}
+
+/**
+ * 401 — The session token has passed its expiration timestamp.
+ */
+export class SessionExpiredError extends AppError {
+  constructor(message: string = 'Session has expired') {
+    super(message, 401, 'INVALID_SESSION');
+  }
+}
+
+/**
+ * 401 — The session token is missing, revoked, or otherwise not found.
+ */
+export class InvalidSessionError extends AppError {
+  constructor(message: string = 'Invalid session') {
+    super(message, 401, 'INVALID_SESSION');
+  }
+}
+
+/**
+ * 503 — A transient failure (e.g. OCC retries exhausted) prevents the
+ * request from being fulfilled right now.
+ */
+export class ServiceUnavailableError extends AppError {
+  constructor(message: string = 'Service temporarily unavailable') {
+    super(message, 503, 'SERVICE_UNAVAILABLE');
+  }
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/passwordHasher.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/passwordHasher.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { hash, verify } from './passwordHasher';
+
+describe('passwordHasher', () => {
+  describe('hash', () => {
+    it('should produce a valid bcrypt hash string', async () => {
+      const result = await hash('mypassword');
+
+      // bcrypt hashes start with $2a$ or $2b$ and are 60 characters long
+      expect(result).toMatch(/^\$2[ab]\$\d{2}\$.{53}$/);
+    });
+
+    it('should use a cost factor of 10', async () => {
+      const result = await hash('testpassword');
+
+      // The cost factor is encoded in the hash: $2a$10$...
+      expect(result).toMatch(/^\$2[ab]\$10\$/);
+    });
+
+    it('should produce different hashes for the same password', async () => {
+      const password = 'samepassword';
+      const hash1 = await hash(password);
+      const hash2 = await hash(password);
+
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+
+  describe('verify', () => {
+    it('should return true for a matching password', async () => {
+      const password = 'correctpassword';
+      const hashed = await hash(password);
+
+      const result = await verify(password, hashed);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false for a non-matching password', async () => {
+      const hashed = await hash('originalpassword');
+
+      const result = await verify('wrongpassword', hashed);
+
+      expect(result).toBe(false);
+    });
+
+    it('should handle passwords at minimum length (8 chars)', async () => {
+      const password = 'abcdefgh';
+      const hashed = await hash(password);
+
+      expect(await verify(password, hashed)).toBe(true);
+    });
+
+    it('should handle passwords at maximum length (128 chars)', async () => {
+      const password = 'a'.repeat(128);
+      const hashed = await hash(password);
+
+      expect(await verify(password, hashed)).toBe(true);
+    });
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/passwordHasher.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/passwordHasher.ts
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------
+// Password Hasher — Application-Layer bcrypt Wrapper
+// ---------------------------------------------------------------------------
+//
+// Aurora DSQL does not support PostgreSQL extensions such as pgcrypto, so all
+// password hashing MUST happen in the application layer. This module provides
+// a thin wrapper around `bcryptjs` (a pure-JS bcrypt implementation) for
+// hashing and verifying passwords.
+//
+// Key behaviours:
+//   • Uses bcrypt with a cost factor of 10 (2^10 = 1 024 iterations).
+//   • Generates a unique random salt for every hash operation, so hashing the
+//     same password twice always produces different output.
+//   • Never stores or returns plaintext passwords.
+//
+// See design document §6 — Password Hasher for the interface contract.
+// ---------------------------------------------------------------------------
+
+import bcrypt from 'bcryptjs';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * bcrypt cost factor (also called "salt rounds").
+ *
+ * A cost factor of 10 means 2^10 = 1 024 key-expansion iterations. This
+ * provides a good balance between security and latency for a proof-of-concept.
+ */
+const COST_FACTOR = 10;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Hash a plaintext password using bcrypt.
+ *
+ * A unique random salt is generated for each call, ensuring that identical
+ * passwords produce different hashes (Requirement 7.2, 7.5).
+ *
+ * @param password - The plaintext password to hash.
+ * @returns The bcrypt hash string (e.g. `$2a$10$...`).
+ */
+export async function hash(password: string): Promise<string> {
+  const salt = await bcrypt.genSalt(COST_FACTOR);
+  return bcrypt.hash(password, salt);
+}
+
+/**
+ * Verify a plaintext password against a bcrypt hash.
+ *
+ * @param password   - The plaintext password provided by the user.
+ * @param hashValue  - The stored bcrypt hash to compare against.
+ * @returns `true` if the password matches the hash, `false` otherwise.
+ */
+export async function verify(
+  password: string,
+  hashValue: string,
+): Promise<boolean> {
+  return bcrypt.compare(password, hashValue);
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/passwordHasher.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/passwordHasher.ts
@@ -61,3 +61,39 @@ export async function verify(
 ): Promise<boolean> {
   return bcrypt.compare(password, hashValue);
 }
+
+// ---------------------------------------------------------------------------
+// Anti-enumeration helper
+// ---------------------------------------------------------------------------
+
+/**
+ * A precomputed bcrypt hash used as a decoy for failed login attempts where
+ * the email does not exist. Without this, the "no-such-user" branch returns
+ * almost immediately while the "wrong-password" branch spends 80–100 ms in
+ * bcrypt — a timing delta that lets attackers enumerate which emails are
+ * registered, even though both branches return identical error messages.
+ *
+ * The hash here is the bcrypt of the literal string "dummy-password" at
+ * cost 10. The actual value is irrelevant; what matters is that we run the
+ * full bcrypt verify path so the timing is indistinguishable from a real
+ * mismatch.
+ */
+const DUMMY_HASH =
+  '$2a$10$CwTycUXWue0Thq9StjUM0uJ8b/l1xXoGQ4f7nWk0bM7lSk0iKxbpe';
+
+/**
+ * Run a bcrypt verify against a fixed dummy hash and discard the result.
+ *
+ * Call this from the "no such user" branch of a login flow to equalize
+ * latency with the "wrong password" branch. This defends against email
+ * enumeration via timing analysis (Requirement 2.4).
+ *
+ * @param password - Any string, typically the password the user submitted.
+ *                   The value is irrelevant; we only care that bcrypt does
+ *                   the same amount of work as a real verify.
+ */
+export async function dummyVerify(password: string): Promise<void> {
+  // Result is intentionally discarded — we just want bcrypt to spend the
+  // same CPU time it would on a real comparison.
+  await bcrypt.compare(password, DUMMY_HASH);
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/retryWithBackoff.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/retryWithBackoff.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  retryWithBackoff,
+  isSerializationError,
+  computeDelay,
+} from './retryWithBackoff';
+import { ServiceUnavailableError } from './errors';
+
+// Mock the sleep function so retries resolve instantly in tests
+vi.mock('./retryWithBackoff', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./retryWithBackoff')>();
+  return {
+    ...actual,
+    sleep: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helper: create a mock PostgreSQL serialization error (SQLSTATE 40001)
+// ---------------------------------------------------------------------------
+function makeSerializationError(message = 'OCC conflict'): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string };
+  err.code = '40001';
+  return err;
+}
+
+// ---------------------------------------------------------------------------
+// isSerializationError
+// ---------------------------------------------------------------------------
+describe('isSerializationError', () => {
+  it('returns true for an error with code "40001"', () => {
+    expect(isSerializationError(makeSerializationError())).toBe(true);
+  });
+
+  it('returns false for a generic Error without a code', () => {
+    expect(isSerializationError(new Error('boom'))).toBe(false);
+  });
+
+  it('returns false for a non-serialization pg error code', () => {
+    const err = new Error('unique violation') as Error & { code: string };
+    err.code = '23505';
+    expect(isSerializationError(err)).toBe(false);
+  });
+
+  it('returns false for null and undefined', () => {
+    expect(isSerializationError(null)).toBe(false);
+    expect(isSerializationError(undefined)).toBe(false);
+  });
+
+  it('returns false for non-object values', () => {
+    expect(isSerializationError('40001')).toBe(false);
+    expect(isSerializationError(40001)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeDelay
+// ---------------------------------------------------------------------------
+describe('computeDelay', () => {
+  it('returns a value between baseDelayMs * 2^attempt and that plus baseDelayMs', () => {
+    const base = 50;
+    const max = 2000;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const delay = computeDelay(attempt, base, max);
+      const lower = base * Math.pow(2, attempt);
+      expect(delay).toBeGreaterThanOrEqual(lower);
+      expect(delay).toBeLessThanOrEqual(Math.min(lower + base, max));
+    }
+  });
+
+  it('caps the delay at maxDelayMs', () => {
+    const delay = computeDelay(20, 50, 2000);
+    expect(delay).toBeLessThanOrEqual(2000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retryWithBackoff
+// ---------------------------------------------------------------------------
+describe('retryWithBackoff', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns the result on first success without retrying', async () => {
+    const op = vi.fn().mockResolvedValue('ok');
+
+    const result = await retryWithBackoff(op);
+
+    expect(result).toBe('ok');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on serialization error and succeeds', async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(makeSerializationError())
+      .mockResolvedValue('recovered');
+
+    const result = await retryWithBackoff(op, {
+      maxRetries: 3,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+    });
+
+    expect(result).toBe('recovered');
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws ServiceUnavailableError after exhausting all retries', async () => {
+    const op = vi.fn().mockRejectedValue(makeSerializationError());
+
+    await expect(
+      retryWithBackoff(op, { maxRetries: 2, baseDelayMs: 10, maxDelayMs: 100 }),
+    ).rejects.toThrow(ServiceUnavailableError);
+
+    // 1 initial + 2 retries = 3 total calls
+    expect(op).toHaveBeenCalledTimes(3);
+  });
+
+  it('propagates non-serialization errors immediately without retrying', async () => {
+    const nonOccError = new Error('connection refused');
+    const op = vi.fn().mockRejectedValue(nonOccError);
+
+    await expect(retryWithBackoff(op)).rejects.toThrow('connection refused');
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs a warning for each OCC conflict', async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(makeSerializationError())
+      .mockRejectedValueOnce(makeSerializationError())
+      .mockResolvedValue('done');
+
+    await retryWithBackoff(op, { maxRetries: 3, baseDelayMs: 10, maxDelayMs: 100 });
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
+    expect((console.warn as ReturnType<typeof vi.fn>).mock.calls[0][0]).toContain('attempt 1');
+    expect((console.warn as ReturnType<typeof vi.fn>).mock.calls[1][0]).toContain('attempt 2');
+  });
+
+  it('respects custom retry options', async () => {
+    const op = vi.fn().mockRejectedValue(makeSerializationError());
+
+    await expect(
+      retryWithBackoff(op, { maxRetries: 1, baseDelayMs: 5, maxDelayMs: 50 }),
+    ).rejects.toThrow(ServiceUnavailableError);
+
+    // 1 initial + 1 retry = 2 total calls
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries the exact number of maxRetries times before failing', async () => {
+    const op = vi.fn().mockRejectedValue(makeSerializationError());
+
+    await expect(
+      retryWithBackoff(op, { maxRetries: 4, baseDelayMs: 10, maxDelayMs: 100 }),
+    ).rejects.toThrow(ServiceUnavailableError);
+
+    // 1 initial + 4 retries = 5 total calls
+    expect(op).toHaveBeenCalledTimes(5);
+  });
+
+  it('succeeds on the last possible retry attempt', async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(makeSerializationError())
+      .mockRejectedValueOnce(makeSerializationError())
+      .mockRejectedValueOnce(makeSerializationError())
+      .mockResolvedValue('last-chance');
+
+    const result = await retryWithBackoff(op, {
+      maxRetries: 3,
+      baseDelayMs: 10,
+      maxDelayMs: 100,
+    });
+
+    expect(result).toBe('last-chance');
+    expect(op).toHaveBeenCalledTimes(4);
+  });
+});

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/retryWithBackoff.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/retryWithBackoff.ts
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------------------
+// OCC Retry Wrapper with Exponential Backoff
+// ---------------------------------------------------------------------------
+//
+// Aurora DSQL uses Optimistic Concurrency Control (OCC). Transactions may fail
+// at commit time with a PostgreSQL serialization error (SQLSTATE 40001) when
+// concurrent modifications conflict. This utility retries the *entire*
+// operation with exponential backoff and random jitter to spread out retries
+// and reduce repeated contention.
+//
+// Usage:
+//   const result = await retryWithBackoff(() => insertUser(pool, user));
+//
+// See: https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-concurrency-control.html
+// ---------------------------------------------------------------------------
+
+import { ServiceUnavailableError } from './errors';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Configuration for the retry behaviour.
+ *
+ * All fields are optional — sensible defaults are applied when omitted.
+ */
+export interface RetryOptions {
+  /** Maximum number of retry attempts after the initial failure (default: 3). */
+  maxRetries: number;
+  /** Base delay in milliseconds before the first retry (default: 50). */
+  baseDelayMs: number;
+  /** Upper bound on the computed delay in milliseconds (default: 2 000). */
+  maxDelayMs: number;
+}
+
+const DEFAULT_OPTIONS: RetryOptions = {
+  maxRetries: 3,
+  baseDelayMs: 50,
+  maxDelayMs: 2000,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * PostgreSQL serialization error SQLSTATE code.
+ *
+ * The `pg` library attaches a `code` property to error objects that maps to
+ * the five-character SQLSTATE value. `40001` means "serialization_failure".
+ */
+const SERIALIZATION_ERROR_CODE = '40001';
+
+/**
+ * Returns `true` when the error is a PostgreSQL serialization failure.
+ *
+ * The `pg` library sets `error.code` to the SQLSTATE string. We check for
+ * `40001` which indicates an OCC conflict in Aurora DSQL.
+ */
+export function isSerializationError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code: unknown }).code === SERIALIZATION_ERROR_CODE
+  );
+}
+
+/**
+ * Compute the backoff delay for a given attempt.
+ *
+ * Formula: min(baseDelayMs × 2^attempt + random_jitter, maxDelayMs)
+ *
+ * The jitter is a random value in [0, baseDelayMs) which helps spread out
+ * retries from multiple concurrent callers.
+ */
+export function computeDelay(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+): number {
+  const exponentialPart = baseDelayMs * Math.pow(2, attempt);
+  const jitter = Math.random() * baseDelayMs;
+  return Math.min(exponentialPart + jitter, maxDelayMs);
+}
+
+/**
+ * Sleep for the given number of milliseconds.
+ *
+ * Exported for testing purposes (allows mocking to speed up tests).
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Main retry function
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute `operation` and transparently retry on OCC serialization errors.
+ *
+ * The operation should represent a *complete* transaction — on retry the
+ * entire operation is re-executed from scratch.
+ *
+ * @param operation - An async function that performs the database work.
+ * @param options   - Optional overrides for retry behaviour.
+ * @returns The value returned by a successful execution of `operation`.
+ * @throws {ServiceUnavailableError} When all retry attempts are exhausted.
+ * @throws The original error when it is *not* a serialization failure.
+ */
+export async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  options?: Partial<RetryOptions>,
+): Promise<T> {
+  const { maxRetries, baseDelayMs, maxDelayMs } = {
+    ...DEFAULT_OPTIONS,
+    ...options,
+  };
+
+  let lastError: unknown;
+
+  // attempt 0 is the initial try; attempts 1..maxRetries are retries
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error: unknown) {
+      // Only retry on serialization (OCC) errors — everything else propagates
+      if (!isSerializationError(error)) {
+        throw error;
+      }
+
+      lastError = error;
+
+      // Log the conflict for observability (Requirement 11.4)
+      console.warn(
+        `[OCC conflict] Serialization error on attempt ${attempt + 1}/${maxRetries + 1}. ` +
+          (attempt < maxRetries
+            ? 'Retrying…'
+            : 'Max retries exhausted.'),
+      );
+
+      // If we still have retries left, back off before the next attempt
+      if (attempt < maxRetries) {
+        const delay = computeDelay(attempt, baseDelayMs, maxDelayMs);
+        await sleep(delay);
+      }
+    }
+  }
+
+  // All retries exhausted — surface a user-friendly 503 error
+  throw new ServiceUnavailableError(
+    'Transaction failed after maximum retry attempts due to concurrent modification conflicts',
+  );
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/retryWithBackoff.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/utils/retryWithBackoff.ts
@@ -149,8 +149,24 @@ export async function retryWithBackoff<T>(
     }
   }
 
-  // All retries exhausted — surface a user-friendly 503 error
+  // All retries exhausted — surface a 503 to the caller, but preserve the
+  // original SQLSTATE / message so operators can diagnose the OCC storm.
+  // We log the underlying error here (in addition to attaching it as
+  // `cause`) so the forensic context is captured even if the caller's
+  // error handler discards causes.
+  console.error(
+    '[OCC conflict] Retries exhausted; surfacing ServiceUnavailableError',
+    {
+      attempts: maxRetries + 1,
+      lastError:
+        lastError instanceof Error
+          ? { message: lastError.message, code: (lastError as { code?: string }).code }
+          : String(lastError),
+    },
+  );
+
   throw new ServiceUnavailableError(
     'Transaction failed after maximum retry attempts due to concurrent modification conflicts',
+    { cause: lastError },
   );
 }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/tsconfig.json
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/vitest.config.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts'],
+    },
+  },
+});


### PR DESCRIPTION
Adds a Node.js + TypeScript sample application demonstrating user authentication and session management on Amazon Aurora DSQL.

The sample shows how to:
- Use IAM-based database authentication via the official DSQL connector
- Generate UUIDs for primary keys in the application layer
- Enforce application-level referential integrity (no foreign keys)
- Implement OCC retry logic with exponential backoff and jitter for serialization errors (SQLSTATE 40001)
- Use CREATE INDEX ASYNC for non-blocking index creation
- Run each DDL statement in its own transaction
- Hash session tokens with SHA-256 (plaintext returned to client once)
- Hash passwords with bcrypt and unique salts in the application layer

Stack: Express.js, node-postgres via @aws/aurora-dsql-node-postgres-connector, Vitest for tests.

By submitting this pull request, I confirm that my contribution is made under 
the terms of the MIT-0 license.

Thank you for your contribution!