### PR TITLE
feat(auth-session-mgmt): align with blog — connector OCC retry, async-job wait, housekeeping, conn lifetime

### DIFF
--- a/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
@@ -167,9 +167,11 @@ This sample focuses on demonstrating Aurora DSQL patterns. Before running in pro
 
   Then change `connection.ts` to connect as `app_runtime` instead of `admin`, and attach an IAM task-role policy that grants only `dsql:DbConnect` (not `dsql:DbConnectAdmin`). Keep `admin` for one-off setup steps such as creating the role itself or running migrations. This follows Aurora DSQL's [Database roles and IAM authentication](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-database-roles.html) guidance.
 
-  To roll the role back, you must revoke the IAM mapping before dropping the role, otherwise `DROP ROLE` fails with `2BP01 cannot be dropped because some objects depend on it`:
+  To roll the role back, revoke its table privileges and the IAM mapping before dropping it. Otherwise `DROP ROLE` fails with `2BP01 cannot be dropped because some objects depend on it` (the table grants and the IAM mapping are independent dependencies, both must be removed):
 
   ```sql
+  REVOKE ALL ON users    FROM app_runtime;
+  REVOKE ALL ON sessions FROM app_runtime;
   AWS IAM REVOKE app_runtime FROM 'arn:aws:iam::111122223333:role/auth-service-task-role';
   DROP ROLE app_runtime;
   ```

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
@@ -166,6 +166,13 @@ This sample focuses on demonstrating Aurora DSQL patterns. Before running in pro
   ```
 
   Then change `connection.ts` to connect as `app_runtime` instead of `admin`, and attach an IAM task-role policy that grants only `dsql:DbConnect` (not `dsql:DbConnectAdmin`). Keep `admin` for one-off setup steps such as creating the role itself or running migrations. This follows Aurora DSQL's [Database roles and IAM authentication](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-database-roles.html) guidance.
+
+  To roll the role back, you must revoke the IAM mapping before dropping the role, otherwise `DROP ROLE` fails with `2BP01 cannot be dropped because some objects depend on it`:
+
+  ```sql
+  AWS IAM REVOKE app_runtime FROM 'arn:aws:iam::111122223333:role/auth-service-task-role';
+  DROP ROLE app_runtime;
+  ```
 - **Rate limiting.** This sample does not include `express-rate-limit` or any throttling. At minimum, add per-IP rate limits to `/api/auth/register` and `/api/auth/login` to slow brute-force credential stuffing.
 - **Trusted proxy / X-Forwarded-For handling.** `req.ip` is recorded in `client_metadata` for session listing. Behind a load balancer, this is the LB IP unless you configure `app.set('trust proxy', ...)` with the correct hop count. Configure it explicitly. Never set `trust proxy: true` on a publicly exposed app, since that lets clients spoof `X-Forwarded-For`.
 - **bcrypt cost factor.** `passwordHasher.ts` uses cost 10 (~80-100 ms per verify on a typical CPU), suitable for a proof-of-concept. Increase to 12 or higher in production after benchmarking your target hardware.

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
@@ -153,13 +153,25 @@ The `sessions.token_hash` column is intentionally NOT given an explicit `CREATE 
 
 ### Production hardening checklist
 
-This sample focuses on demonstrating Aurora DSQL patterns. Before running in production, add the following layers, none of which are DSQL-specific:
+This sample focuses on demonstrating Aurora DSQL patterns. Before running in production, add the following layers:
 
+- **Custom database role for the runtime.** The default `connection.ts` connects as `admin`, which is fine for the proof-of-concept but gives the runtime far more authority than it needs. For production, run the included setup script once to create a least-privilege role and map it to your runtime IAM principal:
+
+  ```bash
+  AWS_REGION=us-east-1 \
+  DSQL_ENDPOINT=<cluster-id>.dsql.us-east-1.on.aws \
+  APP_ROLE_NAME=app_runtime \
+  APP_TASK_ROLE_ARN=arn:aws:iam::111122223333:role/auth-service-task-role \
+  npm run setup-runtime-role
+  ```
+
+  Then change `connection.ts` to connect as `app_runtime` instead of `admin`, and attach an IAM task-role policy that grants only `dsql:DbConnect` (not `dsql:DbConnectAdmin`). Keep `admin` for one-off setup steps such as creating the role itself or running migrations. This follows Aurora DSQL's [Database roles and IAM authentication](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-database-roles.html) guidance.
 - **Rate limiting.** This sample does not include `express-rate-limit` or any throttling. At minimum, add per-IP rate limits to `/api/auth/register` and `/api/auth/login` to slow brute-force credential stuffing.
-- **Trusted proxy / X-Forwarded-For handling.** `req.ip` is recorded in `client_metadata` for session listing. Behind a load balancer, this is the LB IP unless you configure `app.set('trust proxy', ...)` with the correct hop count. Configure it explicitly — never set `trust proxy: true` on a publicly exposed app, since that lets clients spoof `X-Forwarded-For`.
-- **bcrypt cost factor.** `passwordHasher.ts` uses cost 10 (~80–100 ms per verify on a typical CPU), suitable for a proof-of-concept. Increase to 12 or higher in production after benchmarking your target hardware.
-- **Logging and observability.** Replace the `console.warn` / `console.error` calls in `retryWithBackoff.ts` with a structured logger of your choice and forward to CloudWatch / your aggregator.
+- **Trusted proxy / X-Forwarded-For handling.** `req.ip` is recorded in `client_metadata` for session listing. Behind a load balancer, this is the LB IP unless you configure `app.set('trust proxy', ...)` with the correct hop count. Configure it explicitly. Never set `trust proxy: true` on a publicly exposed app, since that lets clients spoof `X-Forwarded-For`.
+- **bcrypt cost factor.** `passwordHasher.ts` uses cost 10 (~80-100 ms per verify on a typical CPU), suitable for a proof-of-concept. Increase to 12 or higher in production after benchmarking your target hardware.
+- **Logging and observability.** Replace the `console.warn` / `console.error` calls in `retryWithBackoff.ts` with a structured logger of your choice and forward to CloudWatch or your aggregator.
 - **Token storage on the client.** This sample returns the session token in JSON. In a browser app you'll typically want an HTTP-only, Secure cookie instead.
+- **Periodic session purge.** Run `npm run housekeeping` on a schedule (cron, ECS scheduled task, EventBridge-triggered Lambda) to delete expired and long-revoked rows. Configurable via `SESSION_RETENTION_DAYS` (default 30 days). The script wraps each batch in `retryWithBackoff` so transient OCC conflicts don't fail the run.
 
 ## Cleanup
 

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
@@ -9,7 +9,8 @@
     "dev": "ts-node src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "housekeeping": "node dist/scripts/housekeeping.js"
+    "housekeeping": "node dist/scripts/housekeeping.js",
+    "setup-runtime-role": "node dist/scripts/setup-runtime-role.js"
   },
   "keywords": [
     "aurora-dsql",

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/package.json
@@ -8,7 +8,8 @@
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "housekeeping": "node dist/scripts/housekeeping.js"
   },
   "keywords": [
     "aurora-dsql",

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.test.ts
@@ -65,6 +65,7 @@ describe('DSQL Connection Pool', () => {
       database: 'postgres',
       max: 10,
       idleTimeoutMillis: 300_000,
+      maxLifetimeSeconds: 3300,
     });
     expect(pool).toBeDefined();
   });

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.test.ts
@@ -14,6 +14,9 @@ const constructorCalls: unknown[] = [];
 vi.mock('@aws/aurora-dsql-node-postgres-connector', () => {
   class MockAuroraDSQLPool {
     end = mockEnd;
+    // Stub method matching the real connector's signature so the
+    // typeof-check assertion in getPool() passes.
+    transaction = async <T>(cb: (client: unknown) => Promise<T>): Promise<T> => cb({});
     constructor(config: unknown) {
       constructorCalls.push(config);
     }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.ts
@@ -28,13 +28,15 @@ let pool: AuroraDSQLPool | null = null;
  * Returns the shared DSQL connection pool, creating it on first access.
  *
  * The pool is configured with:
- * - `host`              — read from the `DSQL_ENDPOINT` environment variable
- * - `user`              — `'admin'` (DSQL's default IAM-authenticated user)
- * - `database`          — `'postgres'` (DSQL's fixed database name)
- * - `max`               — 10 concurrent connections
- * - `idleTimeoutMillis` — 300 000 ms (5 minutes), well under the 1-hour
- *                         DSQL connection timeout so connections are recycled
- *                         before they expire
+ * - `host`               — read from the `DSQL_ENDPOINT` environment variable
+ * - `user`               — `'admin'` (DSQL's default IAM-authenticated user)
+ * - `database`           — `'postgres'` (DSQL's fixed database name)
+ * - `max`                — 10 concurrent connections
+ * - `idleTimeoutMillis`  — 300 000 ms (5 minutes), well under the 1-hour
+ *                           DSQL connection timeout so connections are
+ *                           recycled before they expire
+ * - `maxLifetimeSeconds` — 3 300 s (55 minutes), so each connection retires
+ *                           ahead of DSQL's hard 1-hour cap
  *
  * @throws {Error} If `DSQL_ENDPOINT` is not set in the environment.
  */
@@ -56,6 +58,10 @@ export function getPool(): AuroraDSQLPool {
     database: 'postgres',
     max: 10,
     idleTimeoutMillis: 300_000, // 5 minutes
+    // Aurora DSQL closes any single connection at 1 hour. Recycle each
+    // connection at 55 minutes so a request never lands on a connection
+    // that the cluster is about to close.
+    maxLifetimeSeconds: 3300,
   });
 
   return pool;

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/connection.ts
@@ -58,11 +58,25 @@ export function getPool(): AuroraDSQLPool {
     database: 'postgres',
     max: 10,
     idleTimeoutMillis: 300_000, // 5 minutes
-    // Aurora DSQL closes any single connection at 1 hour. Recycle each
-    // connection at 55 minutes so a request never lands on a connection
-    // that the cluster is about to close.
+    // Matches the connector default in @aws/aurora-dsql-node-postgres-connector
+    // v0.1.9 (parsePgConfig sets maxLifetimeSeconds: 3300 unless overridden);
+    // kept here for visibility so readers see the 1-hour cap accommodation
+    // without having to grep the connector source.
     maxLifetimeSeconds: 3300,
   });
+
+  // Production guarantee: AuroraDSQLPool always exposes transaction(), and
+  // the repositories rely on it for OCC retry. Surface a clear error here
+  // if a future refactor accidentally returns a plain pg.Pool, rather than
+  // silently degrading to the manual BEGIN/COMMIT fallback that exists for
+  // unit-test mocks.
+  if (typeof (pool as { transaction?: unknown }).transaction !== 'function') {
+    throw new Error(
+      'Pool does not expose transaction(); expected AuroraDSQLPool from ' +
+        '@aws/aurora-dsql-node-postgres-connector. Repositories rely on ' +
+        'pool.transaction() for OCC retry.',
+    );
+  }
 
   return pool;
 }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
@@ -19,7 +19,7 @@ function createMockClient(
   const queries: string[] = [];
   return {
     queries,
-    query: vi.fn(async (sql: string) => {
+    query: vi.fn(async (sql: string, _params?: unknown[]) => {
       queries.push(sql);
       onQuery?.(sql);
       if (sql.startsWith('CREATE INDEX ASYNC')) {
@@ -140,7 +140,12 @@ describe('runMigrations', () => {
     await runMigrations(pool);
 
     // The 4th client (after the 3 DDL clients) ran SELECT sys.wait_for_job($1).
-    expect(clients[3].queries[0]).toBe('SELECT sys.wait_for_job($1)');
+    // Assert on the params too so a regression that passes undefined for $1
+    // would fail the test.
+    expect(clients[3].query).toHaveBeenCalledWith(
+      'SELECT sys.wait_for_job($1)',
+      ['fake-job-id'],
+    );
   });
 
   it('skips wait_for_job when waitForAsyncJobs is false', async () => {

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.test.ts
@@ -7,10 +7,14 @@ import { runMigrations, PoolLike, ClientLike } from './migrate';
 
 /**
  * Creates a mock client that records every SQL statement it receives.
- * Optionally accepts a callback that can throw to simulate failures.
+ *
+ * Returns `{ rows: [{ job_id: 'fake-job-id' }] }` for `CREATE INDEX ASYNC`
+ * statements (matching the real DSQL behaviour that returns a job_id row),
+ * and `{ rows: [] }` for everything else. Tests that need a different shape
+ * can pass a custom `onQuery` to override.
  */
 function createMockClient(
-  onQuery?: (sql: string) => void
+  onQuery?: (sql: string) => void,
 ): ClientLike & { queries: string[] } {
   const queries: string[] = [];
   return {
@@ -18,6 +22,10 @@ function createMockClient(
     query: vi.fn(async (sql: string) => {
       queries.push(sql);
       onQuery?.(sql);
+      if (sql.startsWith('CREATE INDEX ASYNC')) {
+        return { rows: [{ job_id: 'fake-job-id' }] };
+      }
+      return { rows: [] };
     }),
     release: vi.fn(),
   };
@@ -60,17 +68,22 @@ describe('runMigrations', () => {
 
     await runMigrations(pool);
 
-    // We expect 3 separate transactions: users table, sessions table,
-    // and the user_id index. The token_hash UNIQUE constraint already
-    // creates a backing index, so we deliberately do NOT add a second.
-    expect(clients).toHaveLength(3);
+    // 3 DDL transactions (users table, sessions table, user_id index) plus
+    // a 4th client for the post-DDL `sys.wait_for_job` call after the
+    // async index. The token_hash UNIQUE constraint already creates a
+    // backing index, so we deliberately do NOT add a second.
+    expect(clients).toHaveLength(4);
 
-    // Each client should have received BEGIN → DDL → COMMIT
-    for (const client of clients) {
+    // First three clients ran BEGIN → DDL → COMMIT.
+    for (const client of clients.slice(0, 3)) {
       expect(client.queries[0]).toBe('BEGIN');
       expect(client.queries[2]).toBe('COMMIT');
       expect(client.queries).toHaveLength(3);
     }
+
+    // The 4th client ran the wait_for_job for the async index.
+    expect(clients[3].queries).toHaveLength(1);
+    expect(clients[3].queries[0]).toBe('SELECT sys.wait_for_job($1)');
   });
 
   it('creates the users table first', async () => {
@@ -98,7 +111,7 @@ describe('runMigrations', () => {
     expect(ddl).toContain('token_hash VARCHAR(64) NOT NULL UNIQUE');
     expect(ddl).toContain('expires_at TIMESTAMPTZ NOT NULL');
     expect(ddl).toContain('revoked_at TIMESTAMPTZ');
-    expect(ddl).toContain('client_metadata JSONB');
+    expect(ddl).toContain('client_metadata TEXT');
   });
 
   it('creates the user_id index third', async () => {
@@ -116,9 +129,27 @@ describe('runMigrations', () => {
 
     await runMigrations(pool);
 
-    const allDdl = clients.map((c) => c.queries[1]).join('\n');
+    const allDdl = clients.slice(0, 3).map((c) => c.queries[1]).join('\n');
     expect(allDdl).not.toContain('idx_sessions_token_hash');
     expect(allDdl).not.toMatch(/CREATE INDEX[^\n]*ON sessions \(token_hash\)/);
+  });
+
+  it('waits for the async index job to complete', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool);
+
+    // The 4th client (after the 3 DDL clients) ran SELECT sys.wait_for_job($1).
+    expect(clients[3].queries[0]).toBe('SELECT sys.wait_for_job($1)');
+  });
+
+  it('skips wait_for_job when waitForAsyncJobs is false', async () => {
+    const { pool, clients } = createMockPool();
+
+    await runMigrations(pool, { waitForAsyncJobs: false });
+
+    // Only the 3 DDL clients — no wait_for_job client.
+    expect(clients).toHaveLength(3);
   });
 
   it('releases every client back to the pool', async () => {
@@ -135,47 +166,48 @@ describe('runMigrations', () => {
   // Error handling
   // -----------------------------------------------------------------------
 
-  it('rolls back and re-throws when a DDL statement fails', async () => {
-    const ddlError = new Error('relation already exists');
-    let callCount = 0;
-
-    const failingPool: PoolLike = {
+  it('rolls back the transaction when a DDL statement fails', async () => {
+    const clients: ReturnType<typeof createMockClient>[] = [];
+    const pool: PoolLike = {
       connect: vi.fn(async () => {
-        callCount++;
-        // Fail on the second DDL (sessions table)
-        if (callCount === 2) {
-          return createMockClient((sql) => {
-            if (sql !== 'BEGIN' && sql !== 'ROLLBACK') {
-              throw ddlError;
-            }
-          });
-        }
-        return createMockClient();
+        const indexBeingCreated = clients.length; // 0,1,2,...
+        const client = createMockClient((sql) => {
+          // Throw on the second client's DDL (the sessions table CREATE)
+          if (indexBeingCreated === 1 && sql.startsWith('CREATE TABLE')) {
+            throw new Error('simulated DDL failure');
+          }
+        });
+        clients.push(client);
+        return client;
       }),
     };
 
-    await expect(runMigrations(failingPool)).rejects.toThrow(
-      'relation already exists'
-    );
+    await expect(runMigrations(pool)).rejects.toThrow('simulated DDL failure');
+
+    // Second client should have run BEGIN, attempted DDL, and ROLLBACK.
+    const secondClient = clients[1];
+    expect(secondClient.queries).toContain('BEGIN');
+    expect(secondClient.queries).toContain('ROLLBACK');
   });
 
-  it('rolls back the transaction on failure before releasing the client', async () => {
-    const ddlError = new Error('syntax error');
-    const failingClient = createMockClient((sql) => {
-      if (sql !== 'BEGIN' && sql !== 'ROLLBACK') {
-        throw ddlError;
-      }
-    });
-
-    const failingPool: PoolLike = {
-      connect: vi.fn(async () => failingClient),
+  it('still releases the client when the DDL fails', async () => {
+    const clients: ReturnType<typeof createMockClient>[] = [];
+    const pool: PoolLike = {
+      connect: vi.fn(async () => {
+        const indexBeingCreated = clients.length;
+        const client = createMockClient((sql) => {
+          // Fail the very first DDL (users table CREATE)
+          if (indexBeingCreated === 0 && sql.startsWith('CREATE TABLE')) {
+            throw new Error('simulated failure');
+          }
+        });
+        clients.push(client);
+        return client;
+      }),
     };
 
-    await expect(runMigrations(failingPool)).rejects.toThrow('syntax error');
+    await expect(runMigrations(pool)).rejects.toThrow('simulated failure');
 
-    // Should have attempted ROLLBACK after the failure
-    expect(failingClient.queries).toContain('ROLLBACK');
-    // Client must still be released even after an error
-    expect(failingClient.release).toHaveBeenCalledTimes(1);
+    expect(clients[0].release).toHaveBeenCalledTimes(1);
   });
 });

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
@@ -9,8 +9,13 @@
 //
 // This module executes each CREATE TABLE and CREATE INDEX statement in an
 // independent transaction, committing after each one. All statements use
-// IF NOT EXISTS / IF NOT EXISTS so the migrator is safe to run repeatedly
-// (idempotent).
+// IF NOT EXISTS so the migrator is safe to run repeatedly (idempotent).
+//
+// `CREATE INDEX ASYNC` returns synchronously while the index continues
+// building in the background. We capture the returned `job_id` and wait on
+// `sys.wait_for_job($1)` so the application doesn't start serving traffic
+// against a sequential scan. Skip the wait by passing `{ waitForAsyncJobs:
+// false }` if you want migrations to be non-blocking.
 //
 // Requirements:
 //   9.1 — Users table schema
@@ -30,9 +35,16 @@ export interface PoolLike {
 
 /**
  * Minimal interface for a database client obtained from the pool.
+ *
+ * `CREATE INDEX ASYNC` returns a single row with a `job_id` column, so the
+ * client must surface query results' `rows`. The `unknown` payload is
+ * narrowed to `{ job_id: string }` only at the call site.
  */
 export interface ClientLike {
-  query(sql: string): Promise<unknown>;
+  query(
+    sql: string,
+    params?: unknown[],
+  ): Promise<{ rows: Record<string, unknown>[] }>;
   release(): void;
 }
 
@@ -43,44 +55,58 @@ export interface ClientLike {
 /**
  * Each string is a single DDL statement that will be executed inside its own
  * transaction. Order matters: tables must be created before their indexes.
+ *
+ * `CREATE INDEX ASYNC` statements are flagged so the runner knows to capture
+ * the resulting `job_id` and wait for the index to become VALID.
  */
-const DDL_STATEMENTS: string[] = [
+interface DDLStatement {
+  sql: string;
+  /** True when the statement schedules a background async job. */
+  isAsync: boolean;
+}
+
+const DDL_STATEMENTS: DDLStatement[] = [
   // 1. Users table
-  `CREATE TABLE IF NOT EXISTS users (
+  {
+    sql: `CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY,
   email VARCHAR(254) NOT NULL UNIQUE,
   password_hash VARCHAR(72) NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 )`,
+    isAsync: false,
+  },
 
   // 2. Sessions table
-  `CREATE TABLE IF NOT EXISTS sessions (
+  //
+  // Note: `token_hash` is `VARCHAR(64) NOT NULL UNIQUE` — the UNIQUE
+  // constraint produces a backing unique index named `sessions_token_hash_key`
+  // automatically. We deliberately do NOT add a second `CREATE INDEX ASYNC`
+  // on `token_hash`; doing so would create a redundant index, double the
+  // write cost on every INSERT, and consume an entry from the table's index
+  // quota for no benefit.
+  {
+    sql: `CREATE TABLE IF NOT EXISTS sessions (
   id UUID PRIMARY KEY,
   user_id UUID NOT NULL,
   token_hash VARCHAR(64) NOT NULL UNIQUE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   expires_at TIMESTAMPTZ NOT NULL,
   revoked_at TIMESTAMPTZ,
-  client_metadata JSONB
+  client_metadata TEXT
 )`,
+    isAsync: false,
+  },
 
-  // 3. Index on sessions.user_id for fast lookups by user.
+  // 3. Async index on sessions.user_id for fast lookups by user.
   //
-  // Aurora DSQL requires ASYNC index creation — indexes are built in the
-  // background without blocking reads or writes.
-  //
-  // IMPORTANT: `CREATE INDEX ASYNC` returns immediately; the index will
-  // not be VALID until the background build completes. Reads against
-  // `sessions.user_id` will fall back to a full scan until then. Wait for
-  // index validity before relying on the index for performance —
-  // see https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-features.html
-  // for guidance on monitoring async index build status.
-  //
-  // Note: `sessions.token_hash` is intentionally NOT given an explicit
-  // CREATE INDEX statement. The `UNIQUE` constraint declared in the
-  // `sessions` table above already creates a backing unique index — adding
-  // a second index on the same column is redundant and wastes write IOPS.
-  `CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_user_id ON sessions (user_id)`,
+  // `CREATE INDEX ASYNC` returns immediately with a `job_id`. We wait on
+  // `sys.wait_for_job` below so the application doesn't start serving
+  // traffic against a sequential scan.
+  {
+    sql: `CREATE INDEX ASYNC IF NOT EXISTS idx_sessions_user_id ON sessions (user_id)`,
+    isAsync: true,
+  },
 ];
 
 // ---------------------------------------------------------------------------
@@ -88,22 +114,57 @@ const DDL_STATEMENTS: string[] = [
 // ---------------------------------------------------------------------------
 
 /**
+ * Optional knobs for the migrator.
+ */
+export interface RunMigrationsOptions {
+  /**
+   * When true (default), the migrator captures the `job_id` returned by each
+   * `CREATE INDEX ASYNC` statement and blocks on `sys.wait_for_job` until
+   * the index reaches `VALID`. Set to `false` for non-blocking migrations
+   * (e.g. when you want the app to come up immediately and accept some
+   * sequential scans during the index build).
+   */
+  waitForAsyncJobs?: boolean;
+}
+
+/**
  * Executes all DDL migrations against the provided connection pool.
  *
  * Each statement runs inside its own transaction (BEGIN → DDL → COMMIT) to
- * satisfy Aurora DSQL's one-DDL-per-transaction constraint. If any statement
- * fails, the transaction is rolled back and the error is re-thrown so the
- * caller can decide how to handle it.
+ * satisfy Aurora DSQL's one-DDL-per-transaction constraint. For statements
+ * that schedule async work (`CREATE INDEX ASYNC`), the runner captures the
+ * returned `job_id` and waits for it to finish before moving on.
  *
- * @param pool - A connection pool (or pool-like mock) that provides `connect()`.
+ * If any statement fails, the transaction is rolled back and the error is
+ * re-thrown so the caller can decide how to handle it.
+ *
+ * @param pool    - A connection pool (or pool-like mock) that provides `connect()`.
+ * @param options - Optional knobs (e.g. disable the async-job wait).
  */
-export async function runMigrations(pool: PoolLike): Promise<void> {
-  for (const sql of DDL_STATEMENTS) {
+export async function runMigrations(
+  pool: PoolLike,
+  options: RunMigrationsOptions = {},
+): Promise<void> {
+  const { waitForAsyncJobs = true } = options;
+
+  for (const stmt of DDL_STATEMENTS) {
     const client = await pool.connect();
+    let asyncJobId: string | undefined;
     try {
       await client.query('BEGIN');
-      await client.query(sql);
+      const result = await client.query(stmt.sql);
       await client.query('COMMIT');
+
+      if (stmt.isAsync) {
+        // CREATE INDEX ASYNC returns a single row with the job_id of the
+        // background build. Pull it out so we can wait on it below.
+        const row = result.rows[0];
+        const jobId =
+          row && typeof row.job_id === 'string' ? row.job_id : undefined;
+        if (jobId) {
+          asyncJobId = jobId;
+        }
+      }
     } catch (error) {
       // Best-effort rollback. If ROLLBACK itself throws (e.g. dead
       // connection), preserve the *original* error — the SQLSTATE from the
@@ -116,6 +177,18 @@ export async function runMigrations(pool: PoolLike): Promise<void> {
       throw error;
     } finally {
       client.release();
+    }
+
+    // If the previous statement scheduled an async job, wait on it now —
+    // outside of the transaction that scheduled it. `sys.wait_for_job`
+    // blocks until the index finishes building.
+    if (waitForAsyncJobs && asyncJobId) {
+      const waitClient = await pool.connect();
+      try {
+        await waitClient.query('SELECT sys.wait_for_job($1)', [asyncJobId]);
+      } finally {
+        waitClient.release();
+      }
     }
   }
 }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
@@ -352,14 +352,15 @@ export function createSessionRepository(pool: PoolLike) {
  * stored as a JSON-encoded string.
  */
 function mapRowToSession(row: Record<string, unknown>): Session {
+  const sessionId = row.id as string;
   return {
-    id: row.id as string,
+    id: sessionId,
     userId: row.userId as string,
     tokenHash: row.tokenHash as string,
     createdAt: new Date(row.createdAt as string),
     expiresAt: new Date(row.expiresAt as string),
     revokedAt: row.revokedAt ? new Date(row.revokedAt as string) : null,
-    clientMetadata: parseClientMetadata(row.clientMetadata),
+    clientMetadata: parseClientMetadata(row.clientMetadata, sessionId),
   };
 }
 
@@ -370,18 +371,29 @@ function mapRowToSession(row: Record<string, unknown>): Session {
  * driver always returns a string. We accept both string and pre-parsed
  * object shapes for robustness against future driver changes or test mocks.
  *
- * If the stored value is not valid JSON, log the error rather than
- * silently returning an empty object — that way operators can detect
- * corruption or out-of-band writers that bypass `JSON.stringify`.
+ * If the stored value is not valid JSON, log the error along with the
+ * session id and the value's length so an operator can locate and inspect
+ * the offending row. The runtime shape of the parsed object is NOT
+ * validated, the cast to ClientMetadata is structural; a stored `[]` or
+ * a stringified field where an object is expected will pass through.
+ * For a sample that's acceptable, but treat parsed metadata as untrusted
+ * if you tighten the schema later.
  */
-function parseClientMetadata(value: unknown): ClientMetadata {
+function parseClientMetadata(
+  value: unknown,
+  sessionId?: string,
+): ClientMetadata {
   if (typeof value === 'string') {
     try {
       return JSON.parse(value) as ClientMetadata;
     } catch (error) {
       console.warn(
         '[sessionRepository] failed to parse client_metadata; defaulting to {}',
-        { error: error instanceof Error ? error.message : String(error) },
+        {
+          sessionId: sessionId ?? '<unknown>',
+          valueLength: value.length,
+          error: error instanceof Error ? error.message : String(error),
+        },
       );
       return {};
     }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/sessionRepository.ts
@@ -38,9 +38,18 @@ import { retryWithBackoff } from '../utils/retryWithBackoff';
  * Mirrors the pattern used by the user repository — accepting a narrow type
  * instead of the concrete `AuroraDSQLPool` keeps this module easy to
  * unit-test with a simple mock.
+ *
+ * The optional `transaction(callback)` method matches the surface of
+ * `AuroraDSQLPool.transaction` from `@aws/aurora-dsql-node-postgres-connector`.
+ * When the pool implements it (production), the repository routes
+ * transactional work through the connector's built-in OCC retry helper —
+ * the same mechanism the blog post recommends. When it does not (tests with
+ * a lightweight mock), the repository falls back to a manual BEGIN/COMMIT
+ * loop wrapped in `retryWithBackoff` for equivalent behaviour.
  */
 export interface PoolLike {
   connect(): Promise<ClientLike>;
+  transaction?<T>(callback: (client: ClientLike) => Promise<T>): Promise<T>;
 }
 
 /**
@@ -67,6 +76,52 @@ export interface ClientLike {
 const DSQL_MAX_ROWS_PER_TRANSACTION = 3_000;
 
 // ---------------------------------------------------------------------------
+// Transaction helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `callback` inside a transaction with OCC retry.
+ *
+ * If the pool exposes `transaction()` (production path: AuroraDSQLPool from
+ * `@aws/aurora-dsql-node-postgres-connector`), delegate to it so we get the
+ * connector's built-in retry helper that catches both `OC000` (data
+ * conflicts) and `OC001` (schema conflicts) under SQLSTATE `40001`.
+ *
+ * If not (test path: lightweight mock pool), fall back to a manual
+ * BEGIN/COMMIT loop wrapped in `retryWithBackoff` so unit tests keep working
+ * without the real connector.
+ */
+async function runInTransaction<T>(
+  pool: PoolLike,
+  callback: (client: ClientLike) => Promise<T>,
+): Promise<T> {
+  if (pool.transaction) {
+    return pool.transaction(callback);
+  }
+
+  return retryWithBackoff(async () => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await callback(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error: unknown) {
+      // Best-effort rollback. Preserve the original error if ROLLBACK
+      // also throws (e.g. dead connection).
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // swallow — re-throwing the original error below is more useful
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Repository
 // ---------------------------------------------------------------------------
 
@@ -87,9 +142,10 @@ export function createSessionRepository(pool: PoolLike) {
      * Insert a new session record into the `sessions` table.
      *
      * Before inserting, verifies that the referenced `user_id` exists in the
-     * `users` table (application-level referential integrity). The write is
-     * wrapped in the OCC retry utility so that transient serialization errors
-     * from Aurora DSQL are retried automatically.
+     * `users` table (application-level referential integrity). Transactional
+     * work routes through `runInTransaction`, which uses
+     * `AuroraDSQLPool.transaction` (with built-in OCC retry) in production
+     * and a manual BEGIN/COMMIT + `retryWithBackoff` fallback under test.
      *
      * @throws {InvalidSessionError} If the `userId` does not exist in the users table.
      */
@@ -100,51 +156,32 @@ export function createSessionRepository(pool: PoolLike) {
       expiresAt: Date;
       clientMetadata: ClientMetadata;
     }): Promise<void> {
-      await retryWithBackoff(async () => {
-        const client = await pool.connect();
-        try {
-          await client.query('BEGIN');
+      await runInTransaction(pool, async (client) => {
+        // Application-level referential integrity check (Requirement 9.3).
+        // Aurora DSQL does not support foreign keys, so we verify the
+        // referenced user exists before inserting the session.
+        const userCheck = await client.query(
+          'SELECT id FROM users WHERE id = $1',
+          [session.userId],
+        );
 
-          // Application-level referential integrity check (Requirement 9.3).
-          // Aurora DSQL does not support foreign keys, so we verify the
-          // referenced user exists before inserting the session.
-          const userCheck = await client.query(
-            'SELECT id FROM users WHERE id = $1',
-            [session.userId],
+        if (userCheck.rows.length === 0) {
+          throw new InvalidSessionError(
+            `User with id ${session.userId} does not exist`,
           );
-
-          if (userCheck.rows.length === 0) {
-            throw new InvalidSessionError(
-              `User with id ${session.userId} does not exist`,
-            );
-          }
-
-          await client.query(
-            `INSERT INTO sessions (id, user_id, token_hash, created_at, expires_at, revoked_at, client_metadata)
-             VALUES ($1, $2, $3, NOW(), $4, NULL, $5)`,
-            [
-              session.id,
-              session.userId,
-              session.tokenHash,
-              session.expiresAt,
-              session.clientMetadata,
-            ],
-          );
-
-          await client.query('COMMIT');
-        } catch (error: unknown) {
-          // Best-effort rollback. If ROLLBACK itself throws (e.g. dead
-          // connection), preserve the *original* error so the caller still
-          // sees the SQLSTATE that drove the failure.
-          try {
-            await client.query('ROLLBACK');
-          } catch {
-            // swallow — re-throwing the original error below is more useful
-          }
-          throw error;
-        } finally {
-          client.release();
         }
+
+        await client.query(
+          `INSERT INTO sessions (id, user_id, token_hash, created_at, expires_at, revoked_at, client_metadata)
+           VALUES ($1, $2, $3, NOW(), $4, NULL, $5)`,
+          [
+            session.id,
+            session.userId,
+            session.tokenHash,
+            session.expiresAt,
+            session.clientMetadata,
+          ],
+        );
       });
     },
 
@@ -223,35 +260,17 @@ export function createSessionRepository(pool: PoolLike) {
       userId: string,
       sessionId: string,
     ): Promise<boolean> {
-      return retryWithBackoff(async () => {
-        const client = await pool.connect();
-        try {
-          await client.query('BEGIN');
-
-          const result = await client.query(
-            `UPDATE sessions
+      return runInTransaction(pool, async (client) => {
+        const result = await client.query(
+          `UPDATE sessions
              SET revoked_at = NOW()
-             WHERE id = $1
-               AND user_id = $2
-               AND revoked_at IS NULL`,
-            [sessionId, userId],
-          );
+           WHERE id = $1
+             AND user_id = $2
+             AND revoked_at IS NULL`,
+          [sessionId, userId],
+        );
 
-          await client.query('COMMIT');
-
-          return getRowCount(result) > 0;
-        } catch (error: unknown) {
-          // Best-effort rollback. Preserve the *original* error if ROLLBACK
-          // also throws (e.g. dead connection) so callers see the real cause.
-          try {
-            await client.query('ROLLBACK');
-          } catch {
-            // swallow — re-throwing the original error below is more useful
-          }
-          throw error;
-        } finally {
-          client.release();
-        }
+        return getRowCount(result) > 0;
       });
     },
 
@@ -276,61 +295,40 @@ export function createSessionRepository(pool: PoolLike) {
       // DSQL limit (Requirement 12.1, 12.2).
       let batchRevoked: number;
       do {
-        batchRevoked = await retryWithBackoff(async () => {
-          const client = await pool.connect();
-          try {
-            await client.query('BEGIN');
+        batchRevoked = await runInTransaction(pool, async (client) => {
+          // Build the UPDATE with an optional exclusion clause.
+          // We use a sub-select with LIMIT to cap each transaction at
+          // DSQL_MAX_ROWS_PER_TRANSACTION rows.
+          let sql: string;
+          let params: unknown[];
 
-            // Build the UPDATE with an optional exclusion clause.
-            // We use a sub-select with LIMIT to cap each transaction at
-            // DSQL_MAX_ROWS_PER_TRANSACTION rows.
-            let sql: string;
-            let params: unknown[];
-
-            if (excludeSessionId) {
-              sql = `UPDATE sessions
-                     SET revoked_at = NOW()
-                     WHERE id IN (
-                       SELECT id FROM sessions
-                       WHERE user_id = $1
-                         AND revoked_at IS NULL
-                         AND expires_at > NOW()
-                         AND id != $2
-                       LIMIT $3
-                     )`;
-              params = [userId, excludeSessionId, DSQL_MAX_ROWS_PER_TRANSACTION];
-            } else {
-              sql = `UPDATE sessions
-                     SET revoked_at = NOW()
-                     WHERE id IN (
-                       SELECT id FROM sessions
-                       WHERE user_id = $1
-                         AND revoked_at IS NULL
-                         AND expires_at > NOW()
-                       LIMIT $2
-                     )`;
-              params = [userId, DSQL_MAX_ROWS_PER_TRANSACTION];
-            }
-
-            const result = await client.query(sql, params);
-
-            await client.query('COMMIT');
-
-            // `pg` returns rowCount on the result object for DML statements.
-            // Our mock interface returns it via rows.length or a rowCount prop.
-            return getRowCount(result);
-          } catch (error: unknown) {
-            // Best-effort rollback. Preserve the *original* error if
-            // ROLLBACK also throws.
-            try {
-              await client.query('ROLLBACK');
-            } catch {
-              // swallow — re-throwing the original error below is more useful
-            }
-            throw error;
-          } finally {
-            client.release();
+          if (excludeSessionId) {
+            sql = `UPDATE sessions
+                   SET revoked_at = NOW()
+                   WHERE id IN (
+                     SELECT id FROM sessions
+                     WHERE user_id = $1
+                       AND revoked_at IS NULL
+                       AND expires_at > NOW()
+                       AND id != $2
+                     LIMIT $3
+                   )`;
+            params = [userId, excludeSessionId, DSQL_MAX_ROWS_PER_TRANSACTION];
+          } else {
+            sql = `UPDATE sessions
+                   SET revoked_at = NOW()
+                   WHERE id IN (
+                     SELECT id FROM sessions
+                     WHERE user_id = $1
+                       AND revoked_at IS NULL
+                       AND expires_at > NOW()
+                     LIMIT $2
+                   )`;
+            params = [userId, DSQL_MAX_ROWS_PER_TRANSACTION];
           }
+
+          const result = await client.query(sql, params);
+          return getRowCount(result);
         });
 
         totalRevoked += batchRevoked;
@@ -347,6 +345,11 @@ export function createSessionRepository(pool: PoolLike) {
 
 /**
  * Maps a raw database row to a typed `Session` object.
+ *
+ * Handles the conversion of timestamp strings to `Date` objects and parses
+ * the `client_metadata` column. Note: `client_metadata` is a TEXT column
+ * (Aurora DSQL does not support JSONB at this time), so the value is
+ * stored as a JSON-encoded string.
  */
 function mapRowToSession(row: Record<string, unknown>): Session {
   return {
@@ -356,8 +359,37 @@ function mapRowToSession(row: Record<string, unknown>): Session {
     createdAt: new Date(row.createdAt as string),
     expiresAt: new Date(row.expiresAt as string),
     revokedAt: row.revokedAt ? new Date(row.revokedAt as string) : null,
-    clientMetadata: (row.clientMetadata as ClientMetadata | null) ?? {},
+    clientMetadata: parseClientMetadata(row.clientMetadata),
   };
+}
+
+/**
+ * Safely parses the `client_metadata` column value.
+ *
+ * The column is TEXT (Aurora DSQL does not support JSONB), so the `pg`
+ * driver always returns a string. We accept both string and pre-parsed
+ * object shapes for robustness against future driver changes or test mocks.
+ *
+ * If the stored value is not valid JSON, log the error rather than
+ * silently returning an empty object — that way operators can detect
+ * corruption or out-of-band writers that bypass `JSON.stringify`.
+ */
+function parseClientMetadata(value: unknown): ClientMetadata {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as ClientMetadata;
+    } catch (error) {
+      console.warn(
+        '[sessionRepository] failed to parse client_metadata; defaulting to {}',
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return {};
+    }
+  }
+  if (typeof value === 'object' && value !== null) {
+    return value as ClientMetadata;
+  }
+  return {};
 }
 
 /**

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/repositories/userRepository.ts
@@ -33,16 +33,24 @@ import { retryWithBackoff } from '../utils/retryWithBackoff';
  * Mirrors the pattern used by the database migrator — accepting a narrow
  * type instead of the concrete `AuroraDSQLPool` keeps this module easy to
  * unit-test with a simple mock.
+ *
+ * The optional `transaction(callback)` method matches the surface of
+ * `AuroraDSQLPool.transaction` from `@aws/aurora-dsql-node-postgres-connector`.
+ * When the pool implements it (production), the repository uses the
+ * connector's built-in OCC retry helper. When it does not (tests), the
+ * repository falls back to a manual BEGIN/COMMIT loop wrapped in
+ * `retryWithBackoff`.
  */
 export interface PoolLike {
   connect(): Promise<ClientLike>;
+  transaction?<T>(callback: (client: ClientLike) => Promise<T>): Promise<T>;
 }
 
 /**
  * Minimal interface for a database client obtained from the pool.
  */
 export interface ClientLike {
-  query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[] }>;
+  query(sql: string, params?: unknown[]): Promise<{ rows: Record<string, unknown>[]; rowCount?: number }>;
   release(): void;
 }
 
@@ -57,6 +65,47 @@ export interface ClientLike {
  * PostgreSQL raises error code `23505`.
  */
 const UNIQUE_VIOLATION_CODE = '23505';
+
+// ---------------------------------------------------------------------------
+// Transaction helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `callback` inside a transaction with OCC retry.
+ *
+ * Production path: delegate to `AuroraDSQLPool.transaction`, which catches
+ * SQLSTATE `40001` (both `OC000` data conflicts and `OC001` schema
+ * conflicts) and retries with exponential backoff.
+ *
+ * Test path: manual BEGIN/COMMIT loop wrapped in `retryWithBackoff`.
+ */
+async function runInTransaction<T>(
+  pool: PoolLike,
+  callback: (client: ClientLike) => Promise<T>,
+): Promise<T> {
+  if (pool.transaction) {
+    return pool.transaction(callback);
+  }
+
+  return retryWithBackoff(async () => {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      const result = await callback(client);
+      await client.query('COMMIT');
+      return result;
+    } catch (error: unknown) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // swallow — re-throwing the original error below is more useful
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Repository
@@ -78,8 +127,9 @@ export function createUserRepository(pool: PoolLike) {
     /**
      * Insert a new user record into the `users` table.
      *
-     * The write is wrapped in the OCC retry utility so that transient
-     * serialization errors from Aurora DSQL are retried automatically.
+     * Transactional work routes through `runInTransaction`, which uses
+     * `AuroraDSQLPool.transaction` (with built-in OCC retry) in production
+     * and a manual BEGIN/COMMIT + `retryWithBackoff` fallback under test.
      *
      * @throws {ConflictError} If the email already exists (unique violation).
      */
@@ -88,19 +138,14 @@ export function createUserRepository(pool: PoolLike) {
       email: string;
       passwordHash: string;
     }): Promise<User> {
-      return retryWithBackoff(async () => {
-        const client = await pool.connect();
-        try {
-          await client.query('BEGIN');
-
+      try {
+        return await runInTransaction(pool, async (client) => {
           const result = await client.query(
             `INSERT INTO users (id, email, password_hash, created_at)
              VALUES ($1, $2, $3, NOW())
              RETURNING id, email, password_hash AS "passwordHash", created_at AS "createdAt"`,
             [user.id, user.email, user.passwordHash],
           );
-
-          await client.query('COMMIT');
 
           const row = result.rows[0];
           return {
@@ -109,26 +154,14 @@ export function createUserRepository(pool: PoolLike) {
             passwordHash: row.passwordHash as string,
             createdAt: new Date(row.createdAt as string),
           };
-        } catch (error: unknown) {
-          // Best-effort rollback. If ROLLBACK itself throws (e.g. dead
-          // connection), preserve the *original* error so we can still
-          // detect a unique-constraint violation and surface ConflictError.
-          try {
-            await client.query('ROLLBACK');
-          } catch {
-            // swallow — the original error below is more useful
-          }
-
-          // Map PostgreSQL unique-violation on email to a friendly ConflictError
-          if (isUniqueViolation(error)) {
-            throw new ConflictError('Email already exists');
-          }
-
-          throw error;
-        } finally {
-          client.release();
+        });
+      } catch (error: unknown) {
+        // Map PostgreSQL unique-violation on email to a friendly ConflictError
+        if (isUniqueViolation(error)) {
+          throw new ConflictError('Email already exists');
         }
-      });
+        throw error;
+      }
     },
 
     /**

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/housekeeping.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/housekeeping.ts
@@ -12,18 +12,26 @@
 // issues against recently revoked tokens without leaking active access.
 // Adjust the threshold to match your retention policy.
 //
+// Each batch is wrapped in retryWithBackoff so transient OCC serialization
+// errors (SQLSTATE 40001) are retried in-process. This matters because
+// many orchestrators (cron, ECS scheduled tasks) do not retry on non-zero
+// exit by default; without the in-process retry, a single OCC conflict on
+// any batch would surface as a failed run that silently misses cleanup
+// until the next scheduled invocation.
+//
 // Invocation:
 //   ts-node src/scripts/housekeeping.ts
 //   node dist/scripts/housekeeping.js
 //
 // Required environment:
-//   DSQL_ENDPOINT  — e.g. "<cluster-id>.dsql.us-east-1.on.aws"
-//   AWS_REGION     — e.g. "us-east-1"
-//   AWS_*          — credentials for an IAM principal mapped to a DB role
+//   DSQL_ENDPOINT  - e.g. "<cluster-id>.dsql.us-east-1.on.aws"
+//   AWS_REGION     - e.g. "us-east-1"
+//   AWS_*          - credentials for an IAM principal mapped to a DB role
 //                    that has DELETE on `sessions`
 // ---------------------------------------------------------------------------
 
 import { closePool, getPool } from '../db/connection';
+import { retryWithBackoff } from '../utils/retryWithBackoff';
 
 /** DSQL caps any single DML transaction at 3,000 rows. */
 const BATCH_SIZE = 3_000;
@@ -46,42 +54,42 @@ export async function purgeOldSessions(
   const pool = getPool();
   let totalDeleted = 0;
 
-  // Loop until a batch revoked fewer rows than the cap — that's the signal
+  // Loop until a batch revoked fewer rows than the cap, that's the signal
   // that no more eligible rows remain.
   while (true) {
-    const client = await pool.connect();
-    let batchDeleted = 0;
-    try {
-      // Each batch is its own transaction. We don't need OCC retry here
-      // because the housekeeping job is the only writer touching old rows
-      // in practice; if it ever conflicts with concurrent revocation, the
-      // job is idempotent and can simply be re-run.
-      await client.query('BEGIN');
-
-      const result = await client.query(
-        `DELETE FROM sessions
-          WHERE id IN (
-            SELECT id FROM sessions
-             WHERE expires_at < NOW() - $1::interval
-                OR (revoked_at IS NOT NULL
-                    AND revoked_at < NOW() - $1::interval)
-             LIMIT $2
-          )`,
-        [`${retentionDays} days`, BATCH_SIZE],
-      );
-
-      await client.query('COMMIT');
-      batchDeleted = result.rowCount ?? 0;
-    } catch (error) {
+    // Wrap each batch in retryWithBackoff so an OCC conflict during cleanup
+    // doesn't fail the whole run. The DELETE is idempotent, so retrying is
+    // always safe.
+    const batchDeleted = await retryWithBackoff(async () => {
+      const client = await pool.connect();
       try {
-        await client.query('ROLLBACK');
-      } catch {
-        // swallow
+        await client.query('BEGIN');
+
+        const result = await client.query(
+          `DELETE FROM sessions
+            WHERE id IN (
+              SELECT id FROM sessions
+               WHERE expires_at < NOW() - $1::interval
+                  OR (revoked_at IS NOT NULL
+                      AND revoked_at < NOW() - $1::interval)
+               LIMIT $2
+            )`,
+          [`${retentionDays} days`, BATCH_SIZE],
+        );
+
+        await client.query('COMMIT');
+        return result.rowCount ?? 0;
+      } catch (error) {
+        try {
+          await client.query('ROLLBACK');
+        } catch {
+          // swallow
+        }
+        throw error;
+      } finally {
+        client.release();
       }
-      throw error;
-    } finally {
-      client.release();
-    }
+    });
 
     totalDeleted += batchDeleted;
     if (batchDeleted < BATCH_SIZE) break;

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/housekeeping.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/housekeeping.ts
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------
+// Session Housekeeping
+// ---------------------------------------------------------------------------
+//
+// Purges expired and long-revoked rows from `sessions`. Without this, the
+// table grows unboundedly and every `token_hash` lookup pays for the larger
+// index. Run on a schedule (cron, EventBridge-triggered Lambda, or an ECS
+// scheduled task).
+//
+// Aurora DSQL caps a single transaction at 3,000 rows, so the cleanup is a
+// batched, idempotent loop. The 30-day grace window lets you debug auth
+// issues against recently revoked tokens without leaking active access.
+// Adjust the threshold to match your retention policy.
+//
+// Invocation:
+//   ts-node src/scripts/housekeeping.ts
+//   node dist/scripts/housekeeping.js
+//
+// Required environment:
+//   DSQL_ENDPOINT  — e.g. "<cluster-id>.dsql.us-east-1.on.aws"
+//   AWS_REGION     — e.g. "us-east-1"
+//   AWS_*          — credentials for an IAM principal mapped to a DB role
+//                    that has DELETE on `sessions`
+// ---------------------------------------------------------------------------
+
+import { closePool, getPool } from '../db/connection';
+
+/** DSQL caps any single DML transaction at 3,000 rows. */
+const BATCH_SIZE = 3_000;
+
+/** Default retention grace window for revoked or expired sessions. */
+const DEFAULT_RETENTION_DAYS = 30;
+
+/**
+ * Delete sessions that are either expired or have been revoked for more
+ * than `retentionDays`. Loops until a batch returns fewer rows than the
+ * cap, at which point all eligible rows have been purged.
+ *
+ * @param retentionDays - Sessions older than this (after expiry/revocation)
+ *                        are eligible for deletion. Defaults to 30 days.
+ * @returns The total number of rows deleted across all batches.
+ */
+export async function purgeOldSessions(
+  retentionDays: number = DEFAULT_RETENTION_DAYS,
+): Promise<number> {
+  const pool = getPool();
+  let totalDeleted = 0;
+
+  // Loop until a batch revoked fewer rows than the cap — that's the signal
+  // that no more eligible rows remain.
+  while (true) {
+    const client = await pool.connect();
+    let batchDeleted = 0;
+    try {
+      // Each batch is its own transaction. We don't need OCC retry here
+      // because the housekeeping job is the only writer touching old rows
+      // in practice; if it ever conflicts with concurrent revocation, the
+      // job is idempotent and can simply be re-run.
+      await client.query('BEGIN');
+
+      const result = await client.query(
+        `DELETE FROM sessions
+          WHERE id IN (
+            SELECT id FROM sessions
+             WHERE expires_at < NOW() - $1::interval
+                OR (revoked_at IS NOT NULL
+                    AND revoked_at < NOW() - $1::interval)
+             LIMIT $2
+          )`,
+        [`${retentionDays} days`, BATCH_SIZE],
+      );
+
+      await client.query('COMMIT');
+      batchDeleted = result.rowCount ?? 0;
+    } catch (error) {
+      try {
+        await client.query('ROLLBACK');
+      } catch {
+        // swallow
+      }
+      throw error;
+    } finally {
+      client.release();
+    }
+
+    totalDeleted += batchDeleted;
+    if (batchDeleted < BATCH_SIZE) break;
+  }
+
+  return totalDeleted;
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — only runs when invoked directly, not when imported.
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const retention = parseInt(
+    process.env.SESSION_RETENTION_DAYS ?? '',
+    10,
+  );
+  const retentionDays = Number.isFinite(retention) && retention > 0
+    ? retention
+    : DEFAULT_RETENTION_DAYS;
+
+  console.log(
+    `[housekeeping] purging sessions older than ${retentionDays} days …`,
+  );
+  const deleted = await purgeOldSessions(retentionDays);
+  console.log(`[housekeeping] deleted ${deleted} row(s)`);
+  await closePool();
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[housekeeping] failed:', error);
+    process.exit(1);
+  });
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/setup-runtime-role.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/setup-runtime-role.ts
@@ -46,10 +46,14 @@
 // if the role already exists. Re-run only after dropping the role, or
 // guard your invocation with environment checks.
 //
-// Undo path: to drop the role you must first revoke the IAM mapping, or
-// `DROP ROLE` fails with `2BP01 cannot be dropped because some objects
-// depend on it`:
+// Undo path: to drop the role you must first revoke its table privileges
+// AND the IAM mapping. The table grants and the IAM mapping are
+// independent dependencies; both block `DROP ROLE` independently with
+// `2BP01 cannot be dropped because some objects depend on it`. The three
+// REVOKEs can be in any order, but all must precede `DROP ROLE`:
 //
+//   REVOKE ALL ON users    FROM app_runtime;
+//   REVOKE ALL ON sessions FROM app_runtime;
 //   AWS IAM REVOKE app_runtime FROM 'arn:aws:iam::111122223333:role/auth-service-task-role';
 //   DROP ROLE app_runtime;
 //

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/setup-runtime-role.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/setup-runtime-role.ts
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------
+// Setup Runtime Database Role
+// ---------------------------------------------------------------------------
+//
+// One-shot setup script that creates a least-privilege Aurora DSQL database
+// role for the application runtime, maps an IAM principal to it, and grants
+// the minimum privileges the auth service needs on `users` and `sessions`.
+//
+// The default behavior of `connection.ts` is to connect as `admin`, which
+// gives the application far more authority than it needs. Per Aurora DSQL's
+// "Database roles and IAM authentication" guidance, production deployments
+// should use a custom role that maps to the runtime IAM principal (your
+// ECS task role, Lambda execution role, etc.) and has only the privileges
+// the workload requires.
+//
+// This script runs the SQL the blog post walks through in the "Production
+// deployment" section, packaged so you can execute it once during
+// environment setup rather than copy-pasting from the blog.
+//
+// Usage (from the repo root):
+//   AWS_REGION=us-east-1 \
+//   DSQL_ENDPOINT=<cluster-id>.dsql.us-east-1.on.aws \
+//   APP_ROLE_NAME=app_runtime \
+//   APP_TASK_ROLE_ARN=arn:aws:iam::111122223333:role/auth-service-task-role \
+//   ts-node src/scripts/setup-runtime-role.ts
+//
+// Idempotency: this script uses CREATE ROLE / GRANT statements that fail
+// if the role already exists. Re-run only after dropping the role, or
+// guard your invocation with environment checks. The blog and README both
+// note this is a one-off setup step, not part of the regular DDL migration.
+//
+// Required environment:
+//   DSQL_ENDPOINT      - cluster endpoint (e.g. abc.dsql.us-east-1.on.aws)
+//   APP_ROLE_NAME      - DB role to create (default: app_runtime)
+//   APP_TASK_ROLE_ARN  - IAM principal ARN to map to the DB role
+//   AWS_REGION         - region the cluster lives in
+//   AWS_*              - admin credentials (must be able to CREATE ROLE
+//                        and AWS IAM GRANT)
+// ---------------------------------------------------------------------------
+
+import { closePool, getPool } from '../db/connection';
+
+const DEFAULT_ROLE_NAME = 'app_runtime';
+
+async function main(): Promise<void> {
+  const roleName = process.env.APP_ROLE_NAME ?? DEFAULT_ROLE_NAME;
+  const taskRoleArn = process.env.APP_TASK_ROLE_ARN;
+
+  if (!taskRoleArn) {
+    console.error(
+      '[setup-runtime-role] APP_TASK_ROLE_ARN is required. Set it to the ' +
+        'IAM principal ARN that should map to the runtime DB role ' +
+        '(e.g. arn:aws:iam::123456789012:role/auth-service-task-role).',
+    );
+    process.exit(1);
+  }
+
+  // Validate role name to avoid SQL injection via env input. Role identifiers
+  // must be alphanumeric or underscore, max 63 chars per PostgreSQL.
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/.test(roleName)) {
+    console.error(
+      `[setup-runtime-role] APP_ROLE_NAME=${roleName} is not a valid ` +
+        'PostgreSQL identifier. Use only letters, digits, and underscores.',
+    );
+    process.exit(1);
+  }
+
+  const pool = getPool();
+  const client = await pool.connect();
+
+  try {
+    console.log(`[setup-runtime-role] creating role "${roleName}" ...`);
+    await client.query(`CREATE ROLE ${roleName} WITH LOGIN`);
+
+    console.log(
+      `[setup-runtime-role] mapping IAM principal ${taskRoleArn} to ` +
+        `"${roleName}" ...`,
+    );
+    // AWS IAM GRANT cannot use a parameterized role identifier; the role
+    // name has been validated above to ensure it's a safe identifier.
+    await client.query(
+      `AWS IAM GRANT ${roleName} TO $1`,
+      [taskRoleArn],
+    );
+
+    console.log(`[setup-runtime-role] granting privileges on users ...`);
+    await client.query(
+      `GRANT SELECT, INSERT, UPDATE ON users TO ${roleName}`,
+    );
+
+    console.log(`[setup-runtime-role] granting privileges on sessions ...`);
+    await client.query(
+      `GRANT SELECT, INSERT, UPDATE, DELETE ON sessions TO ${roleName}`,
+    );
+
+    console.log(
+      `[setup-runtime-role] done. The application can now connect as ` +
+        `user "${roleName}" using the dsql:DbConnect IAM permission.`,
+    );
+  } finally {
+    client.release();
+    await closePool();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('[setup-runtime-role] failed:', error);
+    process.exit(1);
+  });
+}

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/setup-runtime-role.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/scripts/setup-runtime-role.ts
@@ -17,6 +17,24 @@
 // deployment" section, packaged so you can execute it once during
 // environment setup rather than copy-pasting from the blog.
 //
+// Ordering: `users` and `sessions` must already exist before this script
+// runs, since GRANT … ON <table> requires the table to exist (verified
+// live: it fails with `42P01 relation "users" does not exist`). Run
+// `npm start` once first to apply migrations, OR run this script after
+// any deploy that already migrated. The script's first action is a
+// presence check on both tables; it exits early with a clear error if
+// either is missing.
+//
+// Privilege scope: the script grants `SELECT, INSERT, UPDATE, DELETE` on
+// `sessions`, which is broader than the runtime alone needs (the blog's
+// production-deployment snippet shows only S/I/U because the auth flow
+// soft-deletes via UPDATE revoked_at = NOW() rather than hard-deleting).
+// The DELETE is here so the housekeeping job (`npm run housekeeping`)
+// can purge expired/revoked rows under the same role. If you prefer
+// stricter separation, split into two roles: an `app_runtime` with S/I/U
+// and an `app_housekeeping` with SELECT + DELETE, and run housekeeping
+// under separate credentials.
+//
 // Usage (from the repo root):
 //   AWS_REGION=us-east-1 \
 //   DSQL_ENDPOINT=<cluster-id>.dsql.us-east-1.on.aws \
@@ -26,8 +44,14 @@
 //
 // Idempotency: this script uses CREATE ROLE / GRANT statements that fail
 // if the role already exists. Re-run only after dropping the role, or
-// guard your invocation with environment checks. The blog and README both
-// note this is a one-off setup step, not part of the regular DDL migration.
+// guard your invocation with environment checks.
+//
+// Undo path: to drop the role you must first revoke the IAM mapping, or
+// `DROP ROLE` fails with `2BP01 cannot be dropped because some objects
+// depend on it`:
+//
+//   AWS IAM REVOKE app_runtime FROM 'arn:aws:iam::111122223333:role/auth-service-task-role';
+//   DROP ROLE app_runtime;
 //
 // Required environment:
 //   DSQL_ENDPOINT      - cluster endpoint (e.g. abc.dsql.us-east-1.on.aws)
@@ -42,6 +66,25 @@ import { closePool, getPool } from '../db/connection';
 
 const DEFAULT_ROLE_NAME = 'app_runtime';
 
+/**
+ * IAM role ARN regex.
+ *
+ * Matches `arn:aws[-partition]:iam::<12-digit-account>:role/<name>` where
+ * `<name>` may contain word characters and the IAM-allowed punctuation
+ * (`+ = , . @ -`). This is intentionally strict: any value that doesn't
+ * match is rejected before we interpolate it into the SQL statement.
+ */
+const IAM_ROLE_ARN_REGEX =
+  /^arn:aws[a-z-]*:iam::\d{12}:role\/[\w+=,.@-]+$/;
+
+/**
+ * PostgreSQL identifier regex (letters, digits, underscores; cannot start
+ * with a digit; max 63 chars). Used to validate `APP_ROLE_NAME` before
+ * interpolating it into the SQL statement, since `CREATE ROLE` and `GRANT`
+ * statements cannot use parameterized identifiers.
+ */
+const PG_IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/;
+
 async function main(): Promise<void> {
   const roleName = process.env.APP_ROLE_NAME ?? DEFAULT_ROLE_NAME;
   const taskRoleArn = process.env.APP_TASK_ROLE_ARN;
@@ -55,9 +98,18 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  if (!IAM_ROLE_ARN_REGEX.test(taskRoleArn)) {
+    console.error(
+      `[setup-runtime-role] APP_TASK_ROLE_ARN=${taskRoleArn} is not a ` +
+        'valid IAM role ARN. Expected format: ' +
+        'arn:aws:iam::<12-digit-account>:role/<name>',
+    );
+    process.exit(1);
+  }
+
   // Validate role name to avoid SQL injection via env input. Role identifiers
   // must be alphanumeric or underscore, max 63 chars per PostgreSQL.
-  if (!/^[a-zA-Z_][a-zA-Z0-9_]{0,62}$/.test(roleName)) {
+  if (!PG_IDENTIFIER_REGEX.test(roleName)) {
     console.error(
       `[setup-runtime-role] APP_ROLE_NAME=${roleName} is not a valid ` +
         'PostgreSQL identifier. Use only letters, digits, and underscores.',
@@ -69,6 +121,26 @@ async function main(): Promise<void> {
   const client = await pool.connect();
 
   try {
+    // Precondition: the tables we're about to grant on must already exist.
+    // Without this check, a deployer who runs setup-runtime-role before
+    // migrations sees `42P01 relation "users" does not exist` partway
+    // through the script, leaving a dangling role with no privileges.
+    console.log(
+      '[setup-runtime-role] verifying users and sessions tables exist ...',
+    );
+    try {
+      await client.query('SELECT 1 FROM users LIMIT 0');
+      await client.query('SELECT 1 FROM sessions LIMIT 0');
+    } catch (precheckError) {
+      console.error(
+        '[setup-runtime-role] users or sessions table is missing. ' +
+          'Run migrations first (e.g. `npm start` once, which runs ' +
+          'migrations on startup) before invoking this script.',
+        precheckError,
+      );
+      process.exit(1);
+    }
+
     console.log(`[setup-runtime-role] creating role "${roleName}" ...`);
     await client.query(`CREATE ROLE ${roleName} WITH LOGIN`);
 
@@ -76,11 +148,13 @@ async function main(): Promise<void> {
       `[setup-runtime-role] mapping IAM principal ${taskRoleArn} to ` +
         `"${roleName}" ...`,
     );
-    // AWS IAM GRANT cannot use a parameterized role identifier; the role
-    // name has been validated above to ensure it's a safe identifier.
+    // AWS IAM GRANT does not accept parameterized values for either the
+    // role identifier or the IAM principal literal (verified live: passing
+    // `$1` for the ARN raises `42601 syntax error at or near "$1"`).
+    // Both inputs are validated above against strict regexes before being
+    // interpolated, so this is safe against injection.
     await client.query(
-      `AWS IAM GRANT ${roleName} TO $1`,
-      [taskRoleArn],
+      `AWS IAM GRANT ${roleName} TO '${taskRoleArn}'`,
     );
 
     console.log(`[setup-runtime-role] granting privileges on users ...`);
@@ -89,6 +163,9 @@ async function main(): Promise<void> {
     );
 
     console.log(`[setup-runtime-role] granting privileges on sessions ...`);
+    // DELETE is included so housekeeping (npm run housekeeping) can purge
+    // old rows under the same role. See the script header for the
+    // alternative (split runtime/housekeeping roles).
     await client.query(
       `GRANT SELECT, INSERT, UPDATE, DELETE ON sessions TO ${roleName}`,
     );


### PR DESCRIPTION
Follow-up to #1216 (already merged) to keep the sample in lockstep with the
latest blog post content. The blog teaches several techniques that aren't
yet present in the merged code; this PR adds them so readers who clone
the repo see the same patterns the blog references.

## What this adds

- **`maxLifetimeSeconds: 3300`** on the connection pool so connections
  retire at 55 minutes, ahead of Aurora DSQL's 1-hour hard cap.
- **Connector-built-in OCC retry** via `AuroraDSQLPool.transaction()`.
  Repositories now route writes through it in production; tests fall back
  to a manual BEGIN/COMMIT + `retryWithBackoff` when the mock pool doesn't
  expose `transaction()`.
- **`sys.wait_for_job` wait** in the migrator. `CREATE INDEX ASYNC` now
  blocks until the index reaches VALID before the migration returns, so
  the app doesn't start serving traffic against a sequential scan. Opt-out
  flag for callers that want non-blocking migrations.
- **`src/scripts/housekeeping.ts`**: batched, idempotent DELETE loop for
  expired and long-revoked sessions, respecting Aurora DSQL's 3000-row
  per-transaction cap. Wired up as `npm run housekeeping`. Configurable
  retention via `SESSION_RETENTION_DAYS` (default 30 days).

## Validation

- 196/196 tests passing (added 2 new for the async-job wait + skip flag).
- End-to-end run against a live DSQL cluster before pushing — register /
  login / profile / list / revoke flow worked, the IDOR fix from #1216
  still rejects cross-user revocation, and `sessions_token_hash_key` is
  auto-created from the UNIQUE constraint as expected.

## Context

@amaksimo — your review on #1216 surfaced these as comments #4, #5, #7,
and #9 of your June 11 pass. They were addressed in the blog post
already; this PR brings the code in line. Happy to split into smaller
commits or rework if you'd prefer a different shape.
