### PR TITLE
Fix go-recipe-api CI Go version

### DIFF
--- a/.github/workflows/go-recipe-api-integ-tests.yml
+++ b/.github/workflows/go-recipe-api-integ-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
`go/recipe-sharing-api/go.mod` requires `go 1.26.3`, but its integration-test workflow set up Go `1.25`. With `GOTOOLCHAIN=local` (setup-go default), Go refuses to auto-upgrade and the build fails:

\`\`\`
go: go.mod requires go >= 1.26.3 (running go 1.25.11; GOTOOLCHAIN=local)
\`\`\`

This was introduced in #1184, which collapsed `go 1.25.0` + `toolchain go1.26.2` into a single `go 1.26.3` directive, raising the language floor above the workflow's pinned Go.

Fix: bump the workflow's `go-version` to `1.26` to match `go.mod` (consistent with how `go-pgx`/`go-cm` workflows track their modules).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/aurora-dsql-samples/blob/main/LICENSE).