### PR TITLE
Fix go-recipe-api integration test endpoint env var

### DIFF
--- a/.github/workflows/go-recipe-api-integ-tests.yml
+++ b/.github/workflows/go-recipe-api-integ-tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Run integration tests
       working-directory: ./go/recipe-sharing-api
       env:
-        CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+        DSQL_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
         REGION: ${{ needs.create-cluster.outputs.region }}
       run: |
         go test -v ./test/...


### PR DESCRIPTION
The go-recipe-api sample reads `DSQL_ENDPOINT` (in `test/integration_test.go`, `cmd/api/main.go`, `cmd/lambda/main.go`, `deploy.sh`, and `cloudformation.yml`), but the integration-test workflow exported `CLUSTER_ENDPOINT`. The tests failed immediately:

\`\`\`
integration_test.go:36: DSQL_ENDPOINT environment variable is required
--- FAIL: TestChefCRUD
\`\`\`

The env var was renamed from `CLUSTER_ENDPOINT` to `DSQL_ENDPOINT` across the sample in #1184, but the workflow wasn't updated. This was masked until now by the Go-version failure fixed in #1378.

Fix: rename the workflow env var to `DSQL_ENDPOINT` to match the sample.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/aurora-dsql-samples/blob/main/LICENSE).