### PR TITLE
Add CI workflows and README entries for ORM samples

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -35,12 +35,15 @@ jobs:
       python-cm: ${{ steps.detect.outputs.python-cm }}
       python-psycopg2: ${{ steps.detect.outputs.python-psycopg2 }}
       python-psycopg3: ${{ steps.detect.outputs.python-psycopg3 }}
+      python-sqlalchemy: ${{ steps.detect.outputs.python-sqlalchemy }}
+      python-tortoise-orm: ${{ steps.detect.outputs.python-tortoise-orm }}
       ruby-cm: ${{ steps.detect.outputs.ruby-cm }}
       ruby-pg: ${{ steps.detect.outputs.ruby-pg }}
       ruby-rails: ${{ steps.detect.outputs.ruby-rails }}
       ruby-rails-carrental: ${{ steps.detect.outputs.ruby-rails-carrental }}
       rust-cm: ${{ steps.detect.outputs.rust-cm }}
       rust-sqlx: ${{ steps.detect.outputs.rust-sqlx }}
+      typescript-drizzle: ${{ steps.detect.outputs.typescript-drizzle }}
       typescript-prisma: ${{ steps.detect.outputs.typescript-prisma }}
       typescript-sequelize: ${{ steps.detect.outputs.typescript-sequelize }}
       typescript-type-orm: ${{ steps.detect.outputs.typescript-type-orm }}
@@ -72,12 +75,15 @@ jobs:
               'python-cm': ['python/cluster_management/'],
               'python-psycopg2': ['python/psycopg2/'],
               'python-psycopg3': ['python/psycopg/'],
+              'python-sqlalchemy': ['python/sqlalchemy/'],
+              'python-tortoise-orm': ['python/tortoise-orm/'],
               'ruby-cm': ['ruby/cluster_management/'],
               'ruby-pg': ['ruby/ruby-pg/'],
               'ruby-rails': ['ruby/rails/petclinic/'],
               'ruby-rails-carrental': ['ruby/rails/carrental/'],
               'rust-cm': ['rust/cluster_management/'],
               'rust-sqlx': ['rust/sqlx/'],
+              'typescript-drizzle': ['typescript/drizzle/'],
               'typescript-prisma': ['typescript/prisma-multi-region/'],
               'typescript-sequelize': ['typescript/sequelize/'],
               'typescript-type-orm': ['typescript/type-orm/'],
@@ -295,6 +301,22 @@ jobs:
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
 
+  python-sqlalchemy:
+    needs: changes
+    if: needs.changes.outputs.python-sqlalchemy == 'true'
+    uses: ./.github/workflows/python-sqlalchemy-integ-tests.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  python-tortoise-orm:
+    needs: changes
+    if: needs.changes.outputs.python-tortoise-orm == 'true'
+    uses: ./.github/workflows/python-tortoise-orm-integ-tests.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
   ruby-cm:
     needs: changes
     if: needs.changes.outputs.ruby-cm == 'true'
@@ -339,6 +361,14 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust-sqlx == 'true'
     uses: ./.github/workflows/rust-sqlx-integ-test.yml
+    secrets: inherit
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  typescript-drizzle:
+    needs: changes
+    if: needs.changes.outputs.typescript-drizzle == 'true'
+    uses: ./.github/workflows/typescript-drizzle-integ-tests.yml
     secrets: inherit
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
@@ -403,12 +433,15 @@ jobs:
       - python-cm
       - python-psycopg2
       - python-psycopg3
+      - python-sqlalchemy
+      - python-tortoise-orm
       - ruby-cm
       - ruby-pg
       - ruby-rails
       - ruby-rails-carrental
       - rust-cm
       - rust-sqlx
+      - typescript-drizzle
       - typescript-prisma
       - typescript-sequelize
       - typescript-type-orm

--- a/.github/workflows/python-sqlalchemy-integ-tests.yml
+++ b/.github/workflows/python-sqlalchemy-integ-tests.yml
@@ -1,0 +1,76 @@
+name: Python SQLAlchemy integration tests
+
+permissions: {}
+
+on:
+  workflow_call: {}
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  create-cluster:
+    uses: ./.github/workflows/dsql-cluster-create.yml
+    with:
+      workflow_name: python-sqlalchemy
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.PYTHON_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  python-sqlalchemy-integ-test:
+    needs: create-cluster
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
+
+    - name: Cache pip packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ secrets.PYTHON_IAM_ROLE }}
+        aws-region: ${{ needs.create-cluster.outputs.region }}
+
+    - name: Configure and run integration for SQLAlchemy - admin
+      working-directory: ./python/sqlalchemy
+      env:
+        CLUSTER_USER: "admin"
+        CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install --upgrade pip
+        pip install --force-reinstall -r requirements.txt
+        python3 -c "import boto3; print(boto3.__version__)"
+        pip list
+        pytest
+
+  delete-cluster:
+    if: always() && needs.create-cluster.result == 'success'
+    needs: [create-cluster, python-sqlalchemy-integ-test]
+    uses: ./.github/workflows/dsql-cluster-delete.yml
+    with:
+      cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}
+      region: ${{ needs.create-cluster.outputs.region }}
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.PYTHON_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials

--- a/.github/workflows/python-tortoise-orm-integ-tests.yml
+++ b/.github/workflows/python-tortoise-orm-integ-tests.yml
@@ -1,0 +1,77 @@
+name: Python Tortoise ORM integration tests
+
+permissions: {}
+
+on:
+  workflow_call: {}
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  create-cluster:
+    uses: ./.github/workflows/dsql-cluster-create.yml
+    with:
+      workflow_name: python-tortoise-orm
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.PYTHON_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  python-tortoise-orm-integ-test:
+    needs: create-cluster
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.10'
+
+    - name: Cache pip packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ secrets.PYTHON_IAM_ROLE }}
+        aws-region: ${{ needs.create-cluster.outputs.region }}
+
+    - name: Configure and run integration for Tortoise ORM - admin
+      working-directory: ./python/tortoise-orm
+      env:
+        CLUSTER_USER: "admin"
+        CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+        CLUSTER_REGION: ${{ needs.create-cluster.outputs.region }}
+      run: |
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install --upgrade pip
+        pip install --force-reinstall -r requirements.txt
+        python3 -c "import boto3; print(boto3.__version__)"
+        pip list
+        pytest
+
+  delete-cluster:
+    if: always() && needs.create-cluster.result == 'success'
+    needs: [create-cluster, python-tortoise-orm-integ-test]
+    uses: ./.github/workflows/dsql-cluster-delete.yml
+    with:
+      cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}
+      region: ${{ needs.create-cluster.outputs.region }}
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.PYTHON_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials

--- a/.github/workflows/typescript-drizzle-integ-tests.yml
+++ b/.github/workflows/typescript-drizzle-integ-tests.yml
@@ -1,0 +1,64 @@
+name: TypeScript Drizzle integration tests
+
+permissions: {}
+
+on:
+  workflow_call: {}
+  workflow_dispatch:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  create-cluster:
+    uses: ./.github/workflows/dsql-cluster-create.yml
+    with:
+      workflow_name: typescript-drizzle
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.TYPESCRIPT_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+  drizzle-integ-test:
+    needs: create-cluster
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - name: Set up Node
+      uses: actions/setup-node@v6
+      with:
+        node-version: '20.x'
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v6
+      with:
+        role-to-assume: ${{ secrets.TYPESCRIPT_IAM_ROLE }}
+        aws-region: ${{ needs.create-cluster.outputs.region }}
+
+    - name: Configure and run integration for Drizzle
+      working-directory: ./typescript/drizzle
+      env:
+        CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
+        REGION: ${{ needs.create-cluster.outputs.region }}
+        CLUSTER_USER: 'admin'
+      run: |
+        npm ci
+        npm run test
+
+  delete-cluster:
+    if: always() && needs.create-cluster.result == 'success'
+    needs: [create-cluster, drizzle-integ-test]
+    uses: ./.github/workflows/dsql-cluster-delete.yml
+    with:
+      cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}
+      region: ${{ needs.create-cluster.outputs.region }}
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.TYPESCRIPT_IAM_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials

--- a/README.md
+++ b/README.md
@@ -26,10 +26,13 @@ The subdirectories contain code examples for connecting and using Aurora DSQL in
 |   Python    |                [Jupyter](python/jupyter)                |
 |   Python    |               [psycopg](python/psycopg/)                |
 |   Python    |              [psycopg2](python/psycopg2/)               |
+|   Python    |             [SQLAlchemy](python/sqlalchemy)             |
+|   Python    |           [Tortoise ORM](python/tortoise-orm)           |
 |    Ruby     |                   [pg](ruby/ruby-pg)                    |
 |    Ruby     |                   [Rails](ruby/rails)                   |
 |    Rust     |                    [sqlx](rust/sqlx)                    |
-| Typescript  |               [Prisma](typescript/prisma)               |
+| Typescript  |              [Drizzle](typescript/drizzle)              |
+| Typescript  |       [Prisma](typescript/prisma-multi-region)          |
 | Typescript  |            [Sequelize](typescript/sequelize)            |
 | Typescript  |             [TypeORM](typescript/type-orm)              |
 |    Deno     |        [postgres-js](deno/postgres-js/)              |

--- a/python/tortoise-orm/test/test_integration.py
+++ b/python/tortoise-orm/test/test_integration.py
@@ -1,9 +1,10 @@
 """Integration test for the Tortoise ORM Aurora DSQL rideshare example.
 
 Runs the full demo application against a live Aurora DSQL cluster, verifies
-the persisted state, then removes the demo data. Requires CLUSTER_ENDPOINT,
-CLUSTER_REGION, and CLUSTER_USER to be set (provided by CI). Skipped when
-CLUSTER_ENDPOINT is absent so the unit tests can still run standalone.
+the persisted state, then removes the demo data. Requires CLUSTER_ENDPOINT
+and CLUSTER_USER to be set (provided by CI); CLUSTER_REGION is optional and
+defaults to us-east-1. Skipped when those are absent so the unit tests can
+still run standalone.
 """
 
 import importlib
@@ -14,8 +15,8 @@ import pytest
 
 
 @pytest.mark.skipif(
-    not os.environ.get("CLUSTER_ENDPOINT"),
-    reason="CLUSTER_ENDPOINT not set; skipping live integration test",
+    not (os.environ.get("CLUSTER_ENDPOINT") and os.environ.get("CLUSTER_USER")),
+    reason="CLUSTER_ENDPOINT and CLUSTER_USER not set; skipping live integration test",
 )
 @pytest.mark.asyncio
 async def test_rideshare_app_end_to_end():
@@ -50,7 +51,8 @@ async def test_rideshare_app_end_to_end():
 
         assert await Payment.filter(status="completed").count() == 3
     finally:
-        # Clean up so the run is repeatable (rider/driver emails are unique).
+        # Clean up so the run is repeatable: the demo uses fixed rider/driver
+        # emails with a unique constraint, so leftover rows would fail a rerun.
         # Reopen the connection if it was closed (main() calls close_db()).
         if not Tortoise._inited:
             await rider_config.init_db()


### PR DESCRIPTION
## Summary

Adds CI integration-test workflows and root README table entries for the three ORM samples that were missing them, and fixes a broken README link.

## Changes

**New CI workflows (wired into `ci-gate.yml`):**
- `python-sqlalchemy-integ-tests.yml` — create-cluster → pytest → delete-cluster (connector-based, admin). Modeled on `python-psycopg3`.
- `typescript-drizzle-integ-tests.yml` — create-cluster → `npm ci && npm run test` → delete-cluster. Node 20.x (matches the sample's `engines`). Modeled on `typescript-sequelize`.
- `python-tortoise-orm-integ-tests.yml` — create-cluster → pytest against a live cluster → delete-cluster. Runs the end-to-end integration test that now lives in the sample.

**Tortoise ORM integration test (`test_integration.py`):**
- Fixed the skip guard to require both `CLUSTER_ENDPOINT` and `CLUSTER_USER`, so the test skips (rather than errors) when only one is set.
- Corrected a misleading cleanup comment.

**README:**
- Added rows for SQLAlchemy, Tortoise ORM, and Drizzle.
- Fixed the Prisma link: `typescript/prisma` → `typescript/prisma-multi-region` (the old path did not exist).

## Testing

- Tortoise ORM: verified all three env scenarios — full env (10 passed against a live cluster, ~12s), no env (9 passed, 1 skipped), and endpoint-only-no-user (skips correctly).
- Drizzle: `npm ci` → build → jest resolves `dist/test/index.spec.js` locally.
- All 4 workflow YAMLs parse; ci-gate wiring validated (outputs ↔ config ↔ jobs ↔ gate needs); reusable-workflow input/secret contracts match.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/aurora-dsql-samples/blob/main/LICENSE).
