### PR TITLE
Fix SQLAlchemy sample missing psycopg_pool dependency

### DIFF
--- a/python/sqlalchemy/requirements.txt
+++ b/python/sqlalchemy/requirements.txt
@@ -1,4 +1,4 @@
 aurora-dsql-python-connector>=0.2.6
-psycopg[binary]>=3.3.3
+psycopg[binary,pool]>=3.3.3
 sqlalchemy>=2.0.48
 pytest>=9.0.2


### PR DESCRIPTION
## Summary

The `python/sqlalchemy` sample fails at import time because the Aurora DSQL Python Connector (`aurora-dsql-python-connector`) does `from psycopg_pool import ...` when loaded, but `requirements.txt` declared only `psycopg[binary]` — which does not include the pool package.

This adds the `pool` extra (`psycopg[binary,pool]`) so the connector imports and the example runs.

## Change

```diff
- psycopg[binary]>=3.3.3
+ psycopg[binary,pool]>=3.3.3
```

## Testing

Verified against a live Aurora DSQL cluster (us-east-1, admin):

```
test/test_example.py::test_run_example PASSED
1 passed in 9.50s
```

Before the fix, `pytest` could not even collect the suite:
`ModuleNotFoundError: No module named 'psycopg_pool'`.

## Related

Surfaced by the new SQLAlchemy CI workflow added in #1407 (this is the pre-existing dependency gap noted there). This PR turns that check green.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/aurora-dsql-samples/blob/main/LICENSE).