### PR TITLE
Add integration test for Tortoise ORM rideshare sample

### DIFF
--- a/python/tortoise-orm/test/test_integration.py
+++ b/python/tortoise-orm/test/test_integration.py
@@ -1,0 +1,58 @@
+"""Integration test for the Tortoise ORM Aurora DSQL rideshare example.
+
+Runs the full demo application against a live Aurora DSQL cluster, verifies
+the persisted state, then removes the demo data. Requires CLUSTER_ENDPOINT,
+CLUSTER_REGION, and CLUSTER_USER to be set (provided by CI). Skipped when
+CLUSTER_ENDPOINT is absent so the unit tests can still run standalone.
+"""
+
+import importlib
+import os
+from decimal import Decimal
+
+import pytest
+
+
+@pytest.mark.skipif(
+    not os.environ.get("CLUSTER_ENDPOINT"),
+    reason="CLUSTER_ENDPOINT not set; skipping live integration test",
+)
+@pytest.mark.asyncio
+async def test_rideshare_app_end_to_end():
+    """Run the rideshare demo end-to-end and verify the persisted data."""
+    from tortoise import Tortoise
+
+    # Reload config so it reads the real environment rather than any values
+    # left cached by the unit tests, which reload rider_config with mocks.
+    import rider_config
+
+    importlib.reload(rider_config)
+
+    from riders_app import main
+    from cleanup import cleanup
+    from rider_models import Rider, Driver, Ride, Payment
+
+    try:
+        # Runs the full flow: schema creation, CRUD, queries, and OCC retry.
+        await main()
+
+        # main() closes its connections; reopen to verify persisted state.
+        await rider_config.init_db()
+
+        assert await Rider.all().count() == 3
+        assert await Driver.all().count() == 2
+
+        completed_rides = await Ride.filter(status="completed")
+        assert len(completed_rides) == 3
+
+        total_revenue = sum(r.fare_amount for r in completed_rides)
+        assert total_revenue == Decimal("92.25")
+
+        assert await Payment.filter(status="completed").count() == 3
+    finally:
+        # Clean up so the run is repeatable (rider/driver emails are unique).
+        # Reopen the connection if it was closed (main() calls close_db()).
+        if not Tortoise._inited:
+            await rider_config.init_db()
+        await cleanup()
+        await rider_config.close_db()


### PR DESCRIPTION
## Summary

Adds an end-to-end integration test for the Tortoise ORM rideshare sample. Every other sample in the repo has an integration test that exercises a live Aurora DSQL cluster; Tortoise ORM previously had unit tests only.

## What it does

`test/test_integration.py` runs the full `riders_app.main()` demo against a live cluster (schema creation, CRUD, queries, and the OCC retry path), then verifies the persisted state and removes the demo data:

- 3 riders, 2 drivers created
- 3 rides completed, total revenue `$92.25`
- 3 payments completed
- cleanup in `finally` so the run is repeatable (rider/driver emails are unique)

## Testing

Verified locally against a live Aurora DSQL cluster:

```
# with cluster env
10 passed in 14.80s          # 9 unit + 1 integration

# without cluster env
9 passed, 1 skipped in 0.45s # integration test skips, no collection error
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the [project license](https://github.com/aws-samples/aurora-dsql-samples/blob/main/LICENSE).