### PR TITLE
fix: Aurora DSQL auth-session-mgmt sample against current DSQL behaviour

### DIFF
--- a/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/README.md
@@ -167,6 +167,8 @@ This sample focuses on demonstrating Aurora DSQL patterns. Before running in pro
 
   Then change `connection.ts` to connect as `app_runtime` instead of `admin`, and attach an IAM task-role policy that grants only `dsql:DbConnect` (not `dsql:DbConnectAdmin`). Keep `admin` for one-off setup steps such as creating the role itself or running migrations. This follows Aurora DSQL's [Database roles and IAM authentication](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-database-roles.html) guidance.
 
+  **When running as `app_runtime` (or any non-admin role), set `SKIP_MIGRATIONS=true`** so the app doesn't try to `CREATE TABLE` on startup. Aurora DSQL doesn't allow schema-level `GRANT`, so a non-admin role has no path to create tables. Run migrations once as `admin` (the default), then start the runtime process with `SKIP_MIGRATIONS=true npm start`.
+
   To roll the role back, revoke its table privileges and the IAM mapping before dropping it. Otherwise `DROP ROLE` fails with `2BP01 cannot be dropped because some objects depend on it` (the table grants and the IAM mapping are independent dependencies, both must be removed):
 
   ```sql

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
@@ -185,8 +185,8 @@ export async function runMigrations(
     if (waitForAsyncJobs && asyncJobId) {
       const waitClient = await pool.connect();
       try {
-        // DSQL changed sys.wait_for_job from a function to a procedure,
-        // so it must be invoked with CALL, not SELECT.
+        // sys.wait_for_job is a procedure, not a function in DSQL, so it
+        // must be invoked with CALL, not SELECT.
         await waitClient.query('CALL sys.wait_for_job($1)', [asyncJobId]);
       } finally {
         waitClient.release();

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/db/migrate.ts
@@ -185,7 +185,9 @@ export async function runMigrations(
     if (waitForAsyncJobs && asyncJobId) {
       const waitClient = await pool.connect();
       try {
-        await waitClient.query('SELECT sys.wait_for_job($1)', [asyncJobId]);
+        // DSQL changed sys.wait_for_job from a function to a procedure,
+        // so it must be invoked with CALL, not SELECT.
+        await waitClient.query('CALL sys.wait_for_job($1)', [asyncJobId]);
       } finally {
         waitClient.release();
       }

--- a/sample-amazon-aurora-dsql-auth-session-mgmt/src/index.ts
+++ b/sample-amazon-aurora-dsql-auth-session-mgmt/src/index.ts
@@ -59,10 +59,15 @@ async function main(): Promise<void> {
   const pool = getPool();
 
   // Step 3 — Run database migrations (creating tables and indexes).
-  // Each DDL statement runs in its own transaction as required by DSQL.
-  console.log('Running database migrations (creating tables and indexes)...');
-  await runMigrations(pool);
-  console.log('Database migrations complete.');
+  // Skip when SKIP_MIGRATIONS=true, e.g. when running as a least-privilege
+  // runtime role that lacks CREATE on schema public.
+  if (process.env.SKIP_MIGRATIONS === 'true') {
+    console.log('SKIP_MIGRATIONS=true, skipping database migrations.');
+  } else {
+    console.log('Running database migrations (creating tables and indexes)...');
+    await runMigrations(pool);
+    console.log('Database migrations complete.');
+  }
 
   // Step 4 — Create all application dependencies.
   const userRepository = createUserRepository(pool);


### PR DESCRIPTION
## Summary

Two fixes to `sample-amazon-aurora-dsql-auth-session-mgmt/` surfaced by running the sample end-to-end against a fresh Aurora DSQL cluster.

## Changes

### 0314671 - fix: use CALL for sys.wait_for_job

Aurora DSQL defines `sys.wait_for_job` as a procedure, not a function. The migrator's `SELECT sys.wait_for_job($1)` call fails at startup with:


This blocks `npm start` on any fresh DSQL cluster because migrations run at boot. Fixed by changing the invocation to `CALL`.

### 5d4c907 - feat: SKIP_MIGRATIONS env var for non-admin runtime

The README's Production hardening checklist recommends running the app as a least-privilege `app_runtime` role and keeping `admin` for setup. That guidance is unimplementable today because the app calls `runMigrations(pool)` unconditionally on every startup. When the app runs as `app_runtime`, that call fails with `permission denied for schema public` (SQLSTATE 42501). Aurora DSQL doesn't support schema-level `GRANT` (`feature not supported on system entity`), so no privilege-only workaround exists.

Added a `SKIP_MIGRATIONS=true` env var that skips `runMigrations` when set. Also documented in the README's Production hardening section.

## Testing

Ran the full sample end-to-end against a fresh single-Region DSQL cluster in us-east-1: cluster create → migrations (as admin) → all six API endpoints exercised → OCC retry demonstrated via concurrent revoke-all → runtime role setup and switch (with `SKIP_MIGRATIONS=true`) → housekeeping purge → cleanup.
