### PR TITLE
Add Rust Lambda employee lookup sample with Aurora DSQL SQLx Connector

### DIFF
--- a/rust/lambda-employee-lookup/.gitignore
+++ b/rust/lambda-employee-lookup/.gitignore
@@ -1,0 +1,3 @@
+target/
+env.sh
+*.zip

--- a/rust/lambda-employee-lookup/Cargo.toml
+++ b/rust/lambda-employee-lookup/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dsql-employee-lookup"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+lambda_http = "0.13"
+aws-config = "1.5"
+aurora-dsql-sqlx-connector = { version = "0.2", features = ["pool", "occ"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "postgres"] }
+tokio = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+anyhow = "1"
+
+[profile.release]
+strip = true
+lto = true
+opt-level = "z"

--- a/rust/lambda-employee-lookup/Dockerfile
+++ b/rust/lambda-employee-lookup/Dockerfile
@@ -1,0 +1,7 @@
+FROM public.ecr.aws/lambda/provided:al2023-arm64
+
+# Copy the bootstrap binary built by cargo-lambda
+COPY target/lambda/dsql-employee-lookup/bootstrap ${LAMBDA_RUNTIME_DIR}/bootstrap
+
+# Set the handler
+CMD ["bootstrap"]

--- a/rust/lambda-employee-lookup/README.md
+++ b/rust/lambda-employee-lookup/README.md
@@ -1,231 +1,158 @@
-<<<<<<< HEAD
-# Aurora DSQL Samples
+# Aurora DSQL Rust Lambda Employee Lookup
 
-[![Discord chat](https://img.shields.io/discord/1435027294837276802.svg?logo=discord)](https://discord.com/invite/nEF6ksFWru)
+## Overview
 
-This repository contains code examples that demonstrate how to use the [Aurora DSQL](https://aws.amazon.com/rds/aurora/dsql/).
+This code example shows you how to build a serverless Employee Directory API using Rust on AWS Lambda, backed by Aurora DSQL. It demonstrates connecting to Aurora DSQL using the [Aurora DSQL SQLx Connector](https://github.com/awslabs/aurora-dsql-connectors/tree/main/rust/sqlx) with automatic IAM authentication, connection pooling, and TLS.
 
-To get started with Aurora DSQL, create clusters and more information, please refer to [AWS Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
+The Lambda function exposes a `POST /lookup` endpoint via API Gateway that queries an `employees` table with optional name filtering.
 
-## How this repository is organized
+## Run the example
 
-The subdirectories contain code examples for connecting and using Aurora DSQL in each programming language and ORM framework, as well as end-to-end sample applications. The examples demonstrate the most common uses, such as installing clients, handling authentication, performing CRUD operations, and more. Please refer to the [documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/known-issues.html) for a full list of differences and limitations.
+> ⚠️ **Important**
+>
+> - Running this code might result in charges to your AWS account.
+> - We recommend that you grant your code [least privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege). At most, grant only the minimum permissions required to perform the task.
+> - This code is not tested in every AWS Region. For more information, see [AWS Regional Services](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/).
 
-|  Language   |                      Client / ORM                       |
-|:-----------:|:-------------------------------------------------------:|
-|     C++     |                   [libpq](cpp/libpq)                    |
-| C# (dotnet) |     [EF Core](dotnet/ef-core/examples/InventoryApi)     |
-| C# (dotnet) |                 [Npgsql](dotnet/npgsql)                 |
-|     Go      |                     [pgx](go/pgx/)                      |
-|    Java     |            [HikariCP + pgJDBC](java/pgjdbc)             |
-|    Java     |               [Liquibase](java/liquibase)               |
-|    Java     |             [Spring Boot](java/spring_boot)             |
-| JavaScript  |          [AWS Lambda + node-postgres](lambda/)          |
-| JavaScript  | [node-postgres (standalone)](javascript/node-postgres/) |
-| JavaScript  |         [Postgres.js](javascript/postgres-js/)          |
-|   Python    |                [asyncpg](python/asyncpg)                |
-|   Python    |                [Jupyter](python/jupyter)                |
-|   Python    |               [psycopg](python/psycopg/)                |
-|   Python    |              [psycopg2](python/psycopg2/)               |
-|   Python    |             [SQLAlchemy](python/sqlalchemy)             |
-|   Python    |           [Tortoise ORM](python/tortoise-orm)           |
-|    Ruby     |                   [pg](ruby/ruby-pg)                    |
-|    Ruby     |                   [Rails](ruby/rails)                   |
-|    Rust     |                    [sqlx](rust/sqlx)                    |
-| Typescript  |              [Drizzle](typescript/drizzle)              |
-| Typescript  |       [Prisma](typescript/prisma-multi-region)          |
-| Typescript  |            [Sequelize](typescript/sequelize)            |
-| Typescript  |             [TypeORM](typescript/type-orm)              |
-|    Deno     |        [postgres-js](deno/postgres-js/)              |
+### Prerequisites
 
+- You must have an AWS account, and have your default credentials and AWS Region configured as described in [Globally configuring AWS SDKs and tools](https://docs.aws.amazon.com/sdkref/latest/refdocs/creds-config-files.html).
+- You must have [Rust & Cargo](https://rustup.rs/) installed (1.84 or later).
+- You must have [cargo-lambda](https://www.cargo-lambda.info/) installed.
+- You must have [Docker](https://docs.docker.com/get-docker/) or [Finch](https://runfinch.com/) installed and running (for building on macOS).
+- You must have [jq](https://jqlang.github.io/jq/) installed.
+- You must have an Aurora DSQL cluster. See [Getting started with Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html).
 
-|  Language   |                 Cluster Management                  |
-|:-----------:|:---------------------------------------------------:|
-|     C++     |    [cluster_management](cpp/cluster_management)     |
-| C# (dotnet) |   [cluster_management](dotnet/cluster_management)   |
-|     Go      |     [cluster_management](go/cluster_management)     |
-|    Java     |    [cluster_management](java/cluster_management)    |
-| JavaScript  | [cluster_management](javascript/cluster_management) |
-|   Python    |   [cluster_management](python/cluster_management)   |
-|    Ruby     |    [cluster_management](ruby/cluster_management)    |
-|    Rust     |    [cluster_management](rust/cluster_management)    |
+### Configure the environment
 
-
-|  Language   |                    Token Generation                     |
-|:-----------:|:-------------------------------------------------------:|
-|     CLI     |          [generate_token](cli/authentication)           |
-|     C++     |          [generate_token](cpp/authentication)           |
-| C# (dotnet) |         [generate_token](dotnet/authentication)         |
-|     Go      |           [generate_token](go/authentication)           |
-|    Java     |          [generate_token](java/authentication)          |
-| JavaScript  |       [generate_token](javascript/authentication)       |
-|   Python    |         [generate_token](python/authentication)         |
-|    Ruby     |          [generate_token](ruby/authentication)          |
-|    Rust     |          [generate_token](rust/authentication)          |
-
-|                          Sample Applications                          |
-|:---------------------------------------------------------------------:|
-| [Amazon Aurora DSQL Agent](sample-amazon-aurora-dsql-agent) — A sample application showing how to build an AI agent that queries Aurora DSQL using natural language, powered by Strands Agents, Bedrock AgentCore Gateway (MCP), and AgentCore Runtime (A2A) |
-| [Booking API (Deno)](deno/booking-api/postgres-js) — A sample REST API for room/resource bookings built with Deno.serve() and postgres.js via the Aurora DSQL connector. Includes OCC retry handling, unique-window enforcement via an async index, and pooled IAM token auth |
-
-Each example includes language and client-specific instructions as well as instructions to invoke example code.
-
-## Security
-
-See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
-
-## License
-
-This project is licensed under the MIT-0 License.
-=======
-# DSQL Employee Lookup - Test Environment
-
-Test environment for the blog post "Building a Serverless Employee Directory with Rust on AWS Lambda and Amazon Aurora DSQL".
-
-## Architecture
-
-- **Compute**: AWS Lambda (ARM64/Graviton)
-- **Database**: Amazon Aurora DSQL (serverless, PostgreSQL-compatible)
-- **API**: API Gateway HTTP API (POST /lookup)
-
-## Project Structure
-
-```
-dsql-employee-test-env/
-├── src/main.rs                       # Lambda function source code
-├── Cargo.toml                        # Rust dependencies
-├── Dockerfile                        # Container image definition
-├── seed.sql                          # Database schema + sample data
-├── test-api.sh                       # API test script
-├── README.md
-│
-├── deploy/
-│   ├── container/                    # ✅ RECOMMENDED - Container image approach
-│   │   ├── setup.sh                  #    Linux setup script (AWS CLI)
-│   │   ├── cloudformation.yaml       #    CloudFormation template
-│   │   └── main.tf                   #    Terraform configuration
-│   │
-│   └── zip/                          # Zip package approach (250MB limit)
-│       ├── setup.sh                  #    Linux setup script (AWS CLI)
-│       ├── cloudformation.yaml       #    CloudFormation template
-│       └── main.tf                   #    Terraform configuration
-│
-├── setup-finch.sh                    # macOS setup (Finch container runtime)
-└── setup-docker.sh                   # macOS setup (Docker container runtime)
-```
-
-## Deployment Options
-
-### Option 1: Container Image (✅ Recommended)
-
-Deploys Lambda as a container image pushed to ECR.
-
-| Advantage | Detail |
-|-----------|--------|
-| No size limit issues | 10GB limit vs 250MB for zip |
-| No cross-compilation | Build natively on ARM Linux |
-| Simpler CI/CD | Single Docker image = immutable artifact |
-
-**Choose your tool:**
-
-| Tool | File | Usage |
-|------|------|-------|
-| AWS CLI | `deploy/container/setup.sh` | `./setup.sh` |
-| CloudFormation | `deploy/container/cloudformation.yaml` | Pre-requisite: push image to ECR, then deploy |
-| Terraform | `deploy/container/main.tf` | `terraform apply -var="image_uri=..."` |
-
-### Option 2: Zip Package
-
-Deploys Lambda as a `.zip` file. Simpler but limited to 250MB unzipped.
-
-**IMPORTANT:** Requires `[profile.release]` with `strip = true` and `lto = true` in Cargo.toml to keep the binary small enough. Without these, Rust binaries with native crypto crates exceed 250MB.
-
-| Tool | File | Usage |
-|------|------|-------|
-| AWS CLI | `deploy/zip/setup.sh` | `./setup.sh` |
-| CloudFormation | `deploy/zip/cloudformation.yaml` | Pre-requisite: upload zip to S3, then deploy |
-| Terraform | `deploy/zip/main.tf` | `terraform apply -var="zip_path=..."` |
-
-### macOS-Specific Scripts
-
-For building on Apple Silicon Macs (where cross-compilation to Linux fails):
-
-| Script | Container Runtime |
-|--------|-------------------|
-| `setup-finch.sh` | Finch (Amazon corp Mac default) |
-| `setup-docker.sh` | Docker Desktop |
-
-These build inside a Linux container and deploy as a container image to ECR.
-
-## Quick Start (Linux)
+Set environment variables with your cluster details:
 
 ```bash
-# Container approach (recommended)
-cd deploy/container
-chmod +x setup.sh
-./setup.sh
+# e.g. "foo0bar1baz2quux3quuux4.dsql.us-east-1.on.aws"
+export DSQL_ENDPOINT="<your cluster endpoint>"
 
-# OR Zip approach
-cd deploy/zip
-chmod +x setup.sh
-./setup.sh
+# e.g. "us-east-1"
+export AWS_REGION="<your region>"
 ```
 
-## Quick Start (macOS - Apple Silicon)
+### Seed the database
 
-```bash
-# Using Finch
-chmod +x setup-finch.sh
-./setup-finch.sh
-
-# OR using Docker
-chmod +x setup-docker.sh
-./setup-docker.sh
-```
-
-## After Deployment
-
-### 1. Seed the database
-
-Connect to DSQL via the Query Editor in the AWS Console, or via psql:
+Connect to your Aurora DSQL cluster via the Query Editor in the AWS Console or via `psql`, then run the SQL in `seed.sql`:
 
 ```bash
 TOKEN=$(aws dsql generate-db-connect-admin-auth-token \
-  --hostname <YOUR_ENDPOINT> --region us-east-1)
+  --hostname $DSQL_ENDPOINT --region $AWS_REGION)
 
 PGPASSWORD=[REDACTED_PASSWORD] psql \
-  "host=<YOUR_ENDPOINT> port=5432 dbname=postgres user=admin sslmode=require" \
+  "host=$DSQL_ENDPOINT port=5432 dbname=postgres user=admin sslmode=require" \
   -f seed.sql
 ```
 
-### 2. Test the API
+### Deploy
+
+This example supports two deployment approaches: **container image** (recommended) and **zip package**.
+
+#### Option 1: Container image (recommended)
+
+Deploys Lambda as a container image pushed to ECR. No 250MB size limit.
+
+| Tool | File |
+|------|------|
+| AWS CLI (Linux) | `deploy/container/setup.sh` |
+| AWS CLI (macOS + Finch) | `setup-finch.sh` |
+| AWS CLI (macOS + Docker) | `setup-docker.sh` |
+| CloudFormation | `deploy/container/cloudformation.yaml` |
+| Terraform | `deploy/container/main.tf` |
 
 ```bash
+# Linux
+cd deploy/container && chmod +x setup.sh && ./setup.sh
+
+# macOS (Apple Silicon)
+chmod +x setup-finch.sh && ./setup-finch.sh
+```
+
+#### Option 2: Zip package
+
+Deploys Lambda as a `.zip` file. Requires `[profile.release]` settings to keep binary under 250MB.
+
+| Tool | File |
+|------|------|
+| AWS CLI (Linux) | `deploy/zip/setup.sh` |
+| CloudFormation | `deploy/zip/cloudformation.yaml` |
+| Terraform | `deploy/zip/main.tf` |
+
+```bash
+cd deploy/zip && chmod +x setup.sh && ./setup.sh
+```
+
+### Test the API
+
+```bash
+# Search for an employee by name
 curl -X POST https://<API_ENDPOINT>/lookup \
   -H 'Content-Type: application/json' \
   -d '{"name": "Alice"}'
+
+# List all employees
+curl -X POST https://<API_ENDPOINT>/lookup \
+  -H 'Content-Type: application/json' \
+  -d '{}'
 ```
 
 Or use the test script:
+
 ```bash
-chmod +x test-api.sh
-./test-api.sh
+chmod +x test-api.sh && ./test-api.sh
 ```
 
-## Important Notes
+### Clean up
 
-- **Region**: Defaults to `us-east-1`. Edit `REGION` in the setup script to change.
-- **No auth on API**: Skips Cognito JWT auth for simplicity. API is publicly accessible.
-- **seed.sql**: Replace `<ACCOUNT_ID>` with your AWS account ID in the `AWS IAM GRANT` statement.
-- **Build time**: First build ~2-3 min (crate downloads). Subsequent builds are faster.
-- **Binary size**: With `strip + lto`, the binary is ~7 MB. Without them, >250 MB.
+Teardown commands are printed at the end of each setup script. Alternatively:
 
-## Cost
+```bash
+# Container approach
+aws lambda delete-function --function-name dsql-employee-lookup --region us-east-1
+aws apigatewayv2 delete-api --api-id <API_ID> --region us-east-1
+aws ecr delete-repository --repository-name dsql-employee-lookup --force --region us-east-1
+aws dsql delete-cluster --identifier <CLUSTER_ID> --region us-east-1
 
-- **Aurora DSQL**: Pay per DPU (compute + read + write) + storage. Free tier available.
-- **Lambda**: Free tier covers 1M requests/month.
-- **API Gateway**: Free tier covers 1M HTTP API calls/month.
-- **ECR**: 500MB free storage/month (container approach only).
+# Zip approach (no ECR cleanup needed)
+aws lambda delete-function --function-name dsql-employee-lookup --region us-east-1
+aws apigatewayv2 delete-api --api-id <API_ID> --region us-east-1
+aws dsql delete-cluster --identifier <CLUSTER_ID> --region us-east-1
+```
 
-Delete resources when done to avoid ongoing charges (teardown commands printed by each setup script).
->>>>>>> fe26e4f9 (Add Rust Lambda + Aurora DSQL employee lookup sample with DSQL SQLx connector)
+## Project structure
+
+```
+├── src/main.rs           # Lambda function handler + DSQL connection pool
+├── Cargo.toml            # Rust dependencies
+├── Dockerfile            # Container image definition for Lambda
+├── seed.sql              # Database schema + sample employee data
+├── test-api.sh           # API test script
+├── setup-finch.sh        # macOS deployment (Finch)
+├── setup-docker.sh       # macOS deployment (Docker)
+└── deploy/
+    ├── container/        # Container image deployment
+    │   ├── setup.sh
+    │   ├── cloudformation.yaml
+    │   └── main.tf
+    └── zip/              # Zip deployment
+        ├── setup.sh
+        ├── cloudformation.yaml
+        └── main.tf
+```
+
+## Additional information
+
+- [Aurora DSQL Connector for Rust SQLx](https://github.com/awslabs/aurora-dsql-connectors/tree/main/rust/sqlx)
+- [Aurora DSQL User Guide](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/)
+- [AWS Lambda Rust Runtime](https://github.com/awslabs/aws-lambda-rust-runtime)
+- [Aurora DSQL launches Rust and .NET connectors](https://aws.amazon.com/about-aws/whats-new/2026/03/aurora-dsql-rust-npgsql-connectors/)
+
+---
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/rust/lambda-employee-lookup/README.md
+++ b/rust/lambda-employee-lookup/README.md
@@ -1,0 +1,231 @@
+<<<<<<< HEAD
+# Aurora DSQL Samples
+
+[![Discord chat](https://img.shields.io/discord/1435027294837276802.svg?logo=discord)](https://discord.com/invite/nEF6ksFWru)
+
+This repository contains code examples that demonstrate how to use the [Aurora DSQL](https://aws.amazon.com/rds/aurora/dsql/).
+
+To get started with Aurora DSQL, create clusters and more information, please refer to [AWS Documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/getting-started.html)
+
+## How this repository is organized
+
+The subdirectories contain code examples for connecting and using Aurora DSQL in each programming language and ORM framework, as well as end-to-end sample applications. The examples demonstrate the most common uses, such as installing clients, handling authentication, performing CRUD operations, and more. Please refer to the [documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/known-issues.html) for a full list of differences and limitations.
+
+|  Language   |                      Client / ORM                       |
+|:-----------:|:-------------------------------------------------------:|
+|     C++     |                   [libpq](cpp/libpq)                    |
+| C# (dotnet) |     [EF Core](dotnet/ef-core/examples/InventoryApi)     |
+| C# (dotnet) |                 [Npgsql](dotnet/npgsql)                 |
+|     Go      |                     [pgx](go/pgx/)                      |
+|    Java     |            [HikariCP + pgJDBC](java/pgjdbc)             |
+|    Java     |               [Liquibase](java/liquibase)               |
+|    Java     |             [Spring Boot](java/spring_boot)             |
+| JavaScript  |          [AWS Lambda + node-postgres](lambda/)          |
+| JavaScript  | [node-postgres (standalone)](javascript/node-postgres/) |
+| JavaScript  |         [Postgres.js](javascript/postgres-js/)          |
+|   Python    |                [asyncpg](python/asyncpg)                |
+|   Python    |                [Jupyter](python/jupyter)                |
+|   Python    |               [psycopg](python/psycopg/)                |
+|   Python    |              [psycopg2](python/psycopg2/)               |
+|   Python    |             [SQLAlchemy](python/sqlalchemy)             |
+|   Python    |           [Tortoise ORM](python/tortoise-orm)           |
+|    Ruby     |                   [pg](ruby/ruby-pg)                    |
+|    Ruby     |                   [Rails](ruby/rails)                   |
+|    Rust     |                    [sqlx](rust/sqlx)                    |
+| Typescript  |              [Drizzle](typescript/drizzle)              |
+| Typescript  |       [Prisma](typescript/prisma-multi-region)          |
+| Typescript  |            [Sequelize](typescript/sequelize)            |
+| Typescript  |             [TypeORM](typescript/type-orm)              |
+|    Deno     |        [postgres-js](deno/postgres-js/)              |
+
+
+|  Language   |                 Cluster Management                  |
+|:-----------:|:---------------------------------------------------:|
+|     C++     |    [cluster_management](cpp/cluster_management)     |
+| C# (dotnet) |   [cluster_management](dotnet/cluster_management)   |
+|     Go      |     [cluster_management](go/cluster_management)     |
+|    Java     |    [cluster_management](java/cluster_management)    |
+| JavaScript  | [cluster_management](javascript/cluster_management) |
+|   Python    |   [cluster_management](python/cluster_management)   |
+|    Ruby     |    [cluster_management](ruby/cluster_management)    |
+|    Rust     |    [cluster_management](rust/cluster_management)    |
+
+
+|  Language   |                    Token Generation                     |
+|:-----------:|:-------------------------------------------------------:|
+|     CLI     |          [generate_token](cli/authentication)           |
+|     C++     |          [generate_token](cpp/authentication)           |
+| C# (dotnet) |         [generate_token](dotnet/authentication)         |
+|     Go      |           [generate_token](go/authentication)           |
+|    Java     |          [generate_token](java/authentication)          |
+| JavaScript  |       [generate_token](javascript/authentication)       |
+|   Python    |         [generate_token](python/authentication)         |
+|    Ruby     |          [generate_token](ruby/authentication)          |
+|    Rust     |          [generate_token](rust/authentication)          |
+
+|                          Sample Applications                          |
+|:---------------------------------------------------------------------:|
+| [Amazon Aurora DSQL Agent](sample-amazon-aurora-dsql-agent) — A sample application showing how to build an AI agent that queries Aurora DSQL using natural language, powered by Strands Agents, Bedrock AgentCore Gateway (MCP), and AgentCore Runtime (A2A) |
+| [Booking API (Deno)](deno/booking-api/postgres-js) — A sample REST API for room/resource bookings built with Deno.serve() and postgres.js via the Aurora DSQL connector. Includes OCC retry handling, unique-window enforcement via an async index, and pooled IAM token auth |
+
+Each example includes language and client-specific instructions as well as instructions to invoke example code.
+
+## Security
+
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This project is licensed under the MIT-0 License.
+=======
+# DSQL Employee Lookup - Test Environment
+
+Test environment for the blog post "Building a Serverless Employee Directory with Rust on AWS Lambda and Amazon Aurora DSQL".
+
+## Architecture
+
+- **Compute**: AWS Lambda (ARM64/Graviton)
+- **Database**: Amazon Aurora DSQL (serverless, PostgreSQL-compatible)
+- **API**: API Gateway HTTP API (POST /lookup)
+
+## Project Structure
+
+```
+dsql-employee-test-env/
+├── src/main.rs                       # Lambda function source code
+├── Cargo.toml                        # Rust dependencies
+├── Dockerfile                        # Container image definition
+├── seed.sql                          # Database schema + sample data
+├── test-api.sh                       # API test script
+├── README.md
+│
+├── deploy/
+│   ├── container/                    # ✅ RECOMMENDED - Container image approach
+│   │   ├── setup.sh                  #    Linux setup script (AWS CLI)
+│   │   ├── cloudformation.yaml       #    CloudFormation template
+│   │   └── main.tf                   #    Terraform configuration
+│   │
+│   └── zip/                          # Zip package approach (250MB limit)
+│       ├── setup.sh                  #    Linux setup script (AWS CLI)
+│       ├── cloudformation.yaml       #    CloudFormation template
+│       └── main.tf                   #    Terraform configuration
+│
+├── setup-finch.sh                    # macOS setup (Finch container runtime)
+└── setup-docker.sh                   # macOS setup (Docker container runtime)
+```
+
+## Deployment Options
+
+### Option 1: Container Image (✅ Recommended)
+
+Deploys Lambda as a container image pushed to ECR.
+
+| Advantage | Detail |
+|-----------|--------|
+| No size limit issues | 10GB limit vs 250MB for zip |
+| No cross-compilation | Build natively on ARM Linux |
+| Simpler CI/CD | Single Docker image = immutable artifact |
+
+**Choose your tool:**
+
+| Tool | File | Usage |
+|------|------|-------|
+| AWS CLI | `deploy/container/setup.sh` | `./setup.sh` |
+| CloudFormation | `deploy/container/cloudformation.yaml` | Pre-requisite: push image to ECR, then deploy |
+| Terraform | `deploy/container/main.tf` | `terraform apply -var="image_uri=..."` |
+
+### Option 2: Zip Package
+
+Deploys Lambda as a `.zip` file. Simpler but limited to 250MB unzipped.
+
+**IMPORTANT:** Requires `[profile.release]` with `strip = true` and `lto = true` in Cargo.toml to keep the binary small enough. Without these, Rust binaries with native crypto crates exceed 250MB.
+
+| Tool | File | Usage |
+|------|------|-------|
+| AWS CLI | `deploy/zip/setup.sh` | `./setup.sh` |
+| CloudFormation | `deploy/zip/cloudformation.yaml` | Pre-requisite: upload zip to S3, then deploy |
+| Terraform | `deploy/zip/main.tf` | `terraform apply -var="zip_path=..."` |
+
+### macOS-Specific Scripts
+
+For building on Apple Silicon Macs (where cross-compilation to Linux fails):
+
+| Script | Container Runtime |
+|--------|-------------------|
+| `setup-finch.sh` | Finch (Amazon corp Mac default) |
+| `setup-docker.sh` | Docker Desktop |
+
+These build inside a Linux container and deploy as a container image to ECR.
+
+## Quick Start (Linux)
+
+```bash
+# Container approach (recommended)
+cd deploy/container
+chmod +x setup.sh
+./setup.sh
+
+# OR Zip approach
+cd deploy/zip
+chmod +x setup.sh
+./setup.sh
+```
+
+## Quick Start (macOS - Apple Silicon)
+
+```bash
+# Using Finch
+chmod +x setup-finch.sh
+./setup-finch.sh
+
+# OR using Docker
+chmod +x setup-docker.sh
+./setup-docker.sh
+```
+
+## After Deployment
+
+### 1. Seed the database
+
+Connect to DSQL via the Query Editor in the AWS Console, or via psql:
+
+```bash
+TOKEN=$(aws dsql generate-db-connect-admin-auth-token \
+  --hostname <YOUR_ENDPOINT> --region us-east-1)
+
+PGPASSWORD=[REDACTED_PASSWORD] psql \
+  "host=<YOUR_ENDPOINT> port=5432 dbname=postgres user=admin sslmode=require" \
+  -f seed.sql
+```
+
+### 2. Test the API
+
+```bash
+curl -X POST https://<API_ENDPOINT>/lookup \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "Alice"}'
+```
+
+Or use the test script:
+```bash
+chmod +x test-api.sh
+./test-api.sh
+```
+
+## Important Notes
+
+- **Region**: Defaults to `us-east-1`. Edit `REGION` in the setup script to change.
+- **No auth on API**: Skips Cognito JWT auth for simplicity. API is publicly accessible.
+- **seed.sql**: Replace `<ACCOUNT_ID>` with your AWS account ID in the `AWS IAM GRANT` statement.
+- **Build time**: First build ~2-3 min (crate downloads). Subsequent builds are faster.
+- **Binary size**: With `strip + lto`, the binary is ~7 MB. Without them, >250 MB.
+
+## Cost
+
+- **Aurora DSQL**: Pay per DPU (compute + read + write) + storage. Free tier available.
+- **Lambda**: Free tier covers 1M requests/month.
+- **API Gateway**: Free tier covers 1M HTTP API calls/month.
+- **ECR**: 500MB free storage/month (container approach only).
+
+Delete resources when done to avoid ongoing charges (teardown commands printed by each setup script).
+>>>>>>> fe26e4f9 (Add Rust Lambda + Aurora DSQL employee lookup sample with DSQL SQLx connector)

--- a/rust/lambda-employee-lookup/deploy/container/cloudformation.yaml
+++ b/rust/lambda-employee-lookup/deploy/container/cloudformation.yaml
@@ -1,0 +1,112 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  DSQL Employee Lookup - Lambda container image + Aurora DSQL + API Gateway.
+  Pre-requisite: Build and push the container image to ECR before deploying.
+
+# USAGE:
+#   aws cloudformation deploy \
+#     --template-file cloudformation.yaml \
+#     --stack-name dsql-employee-lookup \
+#     --capabilities CAPABILITY_NAMED_IAM \
+#     --parameter-overrides ImageUri=<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/dsql-employee-lookup:latest
+
+Parameters:
+  ImageUri:
+    Type: String
+    Description: ECR image URI (e.g. 123456789.dkr.ecr.us-east-1.amazonaws.com/dsql-employee-lookup:latest)
+
+Resources:
+  # --- Aurora DSQL ---
+  DsqlCluster:
+    Type: AWS::DSQL::Cluster
+    Properties:
+      DeletionProtectionEnabled: false
+      Tags:
+        - Key: Project
+          Value: dsql-employee-lookup
+
+  # --- IAM Role ---
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: dsql-employee-lookup-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: DsqlAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: dsql:DbConnectAdmin
+                Resource: !Sub 'arn:aws:dsql:${AWS::Region}:${AWS::AccountId}:cluster/${DsqlCluster}'
+
+  # --- Lambda (Container Image) ---
+  EmployeeLookupFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dsql-employee-lookup
+      PackageType: Image
+      Code:
+        ImageUri: !Ref ImageUri
+      Role: !GetAtt LambdaRole.Arn
+      Architectures: [arm64]
+      Timeout: 30
+      MemorySize: 128
+      Environment:
+        Variables:
+          DSQL_ENDPOINT: !GetAtt DsqlCluster.Endpoint
+          DSQL_USER: admin
+          RUST_LOG: info
+
+  # --- API Gateway HTTP API ---
+  HttpApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: dsql-employee-api
+      ProtocolType: HTTP
+
+  LambdaIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt EmployeeLookupFunction.Arn
+      PayloadFormatVersion: '2.0'
+
+  LookupRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /lookup
+      Target: !Sub 'integrations/${LambdaIntegration}'
+
+  DefaultStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref HttpApi
+      StageName: '$default'
+      AutoDeploy: true
+
+  LambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref EmployeeLookupFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*'
+
+Outputs:
+  ApiEndpoint:
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/lookup'
+  DsqlEndpoint:
+    Value: !GetAtt DsqlCluster.Endpoint
+  DsqlClusterId:
+    Value: !Ref DsqlCluster

--- a/rust/lambda-employee-lookup/deploy/container/main.tf
+++ b/rust/lambda-employee-lookup/deploy/container/main.tf
@@ -88,12 +88,31 @@ resource "aws_apigatewayv2_route" "lookup" {
   api_id    = aws_apigatewayv2_api.main.id
   route_key = "POST /lookup"
   target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "AWS_IAM"
+}
+
+resource "aws_cloudwatch_log_group" "api_logs" {
+  name              = "/aws/apigateway/${var.function_name}-api"
+  retention_in_days = 14
 }
 
 resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.main.id
   name        = "$default"
   auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+    })
+  }
 }
 
 resource "aws_lambda_permission" "apigw" {

--- a/rust/lambda-employee-lookup/deploy/container/main.tf
+++ b/rust/lambda-employee-lookup/deploy/container/main.tf
@@ -1,0 +1,109 @@
+# =============================================================================
+# DSQL Employee Lookup - Terraform (Container Image)
+# =============================================================================
+# Pre-requisite: Build and push container image to ECR first.
+#
+# USAGE:
+#   terraform init
+#   terraform apply -var="image_uri=<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/dsql-employee-lookup:latest"
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}
+
+provider "aws" { region = var.region }
+
+variable "region"        { default = "us-east-1" }
+variable "image_uri"     { type = string }
+variable "function_name" { default = "dsql-employee-lookup" }
+
+data "aws_caller_identity" "current" {}
+
+# --- Aurora DSQL ---
+resource "aws_dsql_cluster" "main" {
+  deletion_protection_enabled = false
+  tags = { Project = "dsql-employee-lookup" }
+}
+
+# --- IAM Role ---
+resource "aws_iam_role" "lambda" {
+  name = "${var.function_name}-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{ Effect = "Allow", Principal = { Service = "lambda.amazonaws.com" }, Action = "sts:AssumeRole" }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "dsql" {
+  name = "dsql-connect"
+  role = aws_iam_role.lambda.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = "dsql:DbConnectAdmin", Resource = "arn:aws:dsql:${var.region}:${data.aws_caller_identity.current.account_id}:cluster/${aws_dsql_cluster.main.id}" }]
+  })
+}
+
+# --- Lambda (Container Image) ---
+resource "aws_lambda_function" "main" {
+  function_name = var.function_name
+  package_type  = "Image"
+  image_uri     = var.image_uri
+  role          = aws_iam_role.lambda.arn
+  architectures = ["arm64"]
+  timeout       = 30
+  memory_size   = 128
+  environment {
+    variables = {
+      DSQL_ENDPOINT = aws_dsql_cluster.main.endpoint
+      DSQL_USER     = "admin"
+      RUST_LOG      = "info"
+    }
+  }
+  depends_on = [aws_iam_role_policy_attachment.basic, aws_iam_role_policy.dsql]
+}
+
+# --- API Gateway ---
+resource "aws_apigatewayv2_api" "main" {
+  name          = "${var.function_name}-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.main.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "lookup" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "POST /lookup"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "apigw" {
+  function_name = aws_lambda_function.main.function_name
+  action        = "lambda:InvokeFunction"
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.main.execution_arn}/*"
+}
+
+# --- Outputs ---
+output "api_endpoint"    { value = "${aws_apigatewayv2_api.main.api_endpoint}/lookup" }
+output "dsql_endpoint"   { value = aws_dsql_cluster.main.endpoint }
+output "dsql_cluster_id" { value = aws_dsql_cluster.main.id }

--- a/rust/lambda-employee-lookup/deploy/container/main.tf
+++ b/rust/lambda-employee-lookup/deploy/container/main.tf
@@ -93,7 +93,7 @@ resource "aws_apigatewayv2_route" "lookup" {
 
 resource "aws_cloudwatch_log_group" "api_logs" {
   name              = "/aws/apigateway/${var.function_name}-api"
-  retention_in_days = 14
+  retention_in_days = 365
 }
 
 resource "aws_apigatewayv2_stage" "default" {

--- a/rust/lambda-employee-lookup/deploy/container/setup.sh
+++ b/rust/lambda-employee-lookup/deploy/container/setup.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# =============================================================================
+# DSQL Employee Lookup - Container Image Deployment (Linux)
+# =============================================================================
+# Deploys Lambda as a container image pushed to ECR (10GB limit).
+# Run this on a Linux machine or in a Linux CI/CD pipeline.
+#
+# Prerequisites:
+#   - AWS CLI v2 configured with credentials
+#   - Docker installed and running
+#   - Rust 1.84+ and cargo-lambda installed
+#   - jq installed
+#
+# Usage:
+#   chmod +x setup.sh
+#   ./setup.sh
+# =============================================================================
+
+set -euo pipefail
+
+REGION="us-east-1"
+FUNCTION_NAME="dsql-employee-lookup"
+ROLE_NAME="dsql-employee-lookup-role"
+API_NAME="dsql-employee-api"
+ECR_REPO="${FUNCTION_NAME}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${ECR_REPO}"
+
+echo "============================================"
+echo "DSQL Employee Lookup - Container Deployment"
+echo "============================================"
+echo "Region:  $REGION"
+echo "Account: $ACCOUNT_ID"
+echo ""
+
+# =============================================================================
+# STEP 1: Create Aurora DSQL cluster
+# =============================================================================
+echo ">>> Step 1: Aurora DSQL cluster..."
+
+read -p "    Do you already have a DSQL cluster? (y/N): " has_cluster
+if [[ "$has_cluster" == "y" || "$has_cluster" == "Y" ]]; then
+  read -p "    Enter cluster endpoint: " CLUSTER_ENDPOINT
+  CLUSTER_ID=$(echo $CLUSTER_ENDPOINT | cut -d'.' -f1)
+else
+  echo "    Creating cluster..."
+  CLUSTER_OUTPUT=$(aws dsql create-cluster \
+    --no-deletion-protection-enabled \
+    --region $REGION \
+    --output json)
+
+  CLUSTER_ID=$(echo $CLUSTER_OUTPUT | jq -r '.identifier')
+  CLUSTER_ENDPOINT=$(echo $CLUSTER_OUTPUT | jq -r '.endpoint')
+
+  echo "    Cluster ID: $CLUSTER_ID"
+  echo "    Endpoint:   $CLUSTER_ENDPOINT"
+  echo "    Waiting for cluster to become ACTIVE..."
+
+  while true; do
+    STATUS=$(aws dsql get-cluster --identifier $CLUSTER_ID --region $REGION --query 'status' --output text 2>/dev/null || echo "CREATING")
+    if [ "$STATUS" == "ACTIVE" ]; then break; fi
+    echo "    Status: $STATUS - waiting..."
+    sleep 10
+  done
+  echo "    Cluster is ACTIVE!"
+fi
+echo ""
+
+# =============================================================================
+# STEP 2: Build Rust binary (native on Linux - no cross-compilation)
+# =============================================================================
+echo ">>> Step 2: Building Rust Lambda binary..."
+
+cargo lambda build --release --arm64 --output-format binary
+
+echo "    Binary built: target/lambda/${FUNCTION_NAME}/bootstrap"
+echo ""
+
+# =============================================================================
+# STEP 3: Build container image and push to ECR
+# =============================================================================
+echo ">>> Step 3: Building and pushing container image to ECR..."
+
+aws ecr create-repository \
+  --repository-name $ECR_REPO \
+  --region $REGION 2>/dev/null || echo "    ECR repo already exists"
+
+aws ecr get-login-password --region $REGION | \
+  docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
+
+# Use the Dockerfile from the project root
+docker build --platform linux/arm64 -t ${ECR_URI}:latest -f ../../Dockerfile ../..
+
+docker push ${ECR_URI}:latest
+
+echo "    Image pushed: ${ECR_URI}:latest"
+echo ""
+
+# =============================================================================
+# STEP 4: Create IAM Role
+# =============================================================================
+echo ">>> Step 4: Creating IAM role..."
+
+aws iam create-role \
+  --role-name $ROLE_NAME \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+  --output text --query 'Role.Arn' 2>/dev/null || echo "    Role already exists"
+
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+
+aws iam attach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole 2>/dev/null || true
+
+aws iam put-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-name dsql-connect \
+  --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"dsql:DbConnectAdmin\",\"Resource\":\"arn:aws:dsql:${REGION}:${ACCOUNT_ID}:cluster/${CLUSTER_ID}\"}]}"
+
+echo "    IAM role configured. Waiting for propagation..."
+sleep 10
+echo ""
+
+# =============================================================================
+# STEP 5: Create Lambda function (container image)
+# =============================================================================
+echo ">>> Step 5: Creating Lambda function..."
+
+aws lambda create-function \
+  --function-name $FUNCTION_NAME \
+  --package-type Image \
+  --code ImageUri=${ECR_URI}:latest \
+  --role $ROLE_ARN \
+  --architectures arm64 \
+  --timeout 30 \
+  --memory-size 128 \
+  --environment "Variables={DSQL_ENDPOINT=$CLUSTER_ENDPOINT,DSQL_USER=admin,RUST_LOG=info}" \
+  --region $REGION \
+  --output text --query 'FunctionArn'
+
+echo "    Waiting for function to be active..."
+aws lambda wait function-active-v2 --function-name $FUNCTION_NAME --region $REGION
+echo "    Lambda deployed!"
+echo ""
+
+# =============================================================================
+# STEP 6: Create API Gateway HTTP API
+# =============================================================================
+echo ">>> Step 6: Creating API Gateway..."
+
+API_OUTPUT=$(aws apigatewayv2 create-api \
+  --name $API_NAME --protocol-type HTTP --region $REGION --output json)
+API_ID=$(echo $API_OUTPUT | jq -r '.ApiId')
+API_ENDPOINT=$(echo $API_OUTPUT | jq -r '.ApiEndpoint')
+
+FUNCTION_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+
+INTEGRATION_ID=$(aws apigatewayv2 create-integration \
+  --api-id $API_ID --integration-type AWS_PROXY \
+  --integration-uri $FUNCTION_ARN --payload-format-version "2.0" \
+  --region $REGION --output text --query 'IntegrationId')
+
+aws apigatewayv2 create-route --api-id $API_ID \
+  --route-key "POST /lookup" --target "integrations/$INTEGRATION_ID" \
+  --region $REGION > /dev/null
+
+aws apigatewayv2 create-stage --api-id $API_ID \
+  --stage-name '$default' --auto-deploy --region $REGION > /dev/null
+
+aws lambda add-permission --function-name $FUNCTION_NAME \
+  --statement-id apigateway-invoke --action lambda:InvokeFunction \
+  --principal apigateway.amazonaws.com \
+  --source-arn "arn:aws:execute-api:${REGION}:${ACCOUNT_ID}:${API_ID}/*" \
+  --region $REGION > /dev/null
+
+echo "    API Gateway configured!"
+echo ""
+
+# =============================================================================
+# DONE
+# =============================================================================
+echo "============================================"
+echo "SETUP COMPLETE!"
+echo "============================================"
+echo ""
+echo "  DSQL Endpoint: $CLUSTER_ENDPOINT"
+echo "  API Endpoint:  ${API_ENDPOINT}/lookup"
+echo "  ECR Image:     ${ECR_URI}:latest"
+echo ""
+echo "Test: curl -X POST ${API_ENDPOINT}/lookup -H 'Content-Type: application/json' -d '{\"name\":\"Alice\"}'"
+echo ""
+echo "Teardown:"
+echo "  aws lambda delete-function --function-name $FUNCTION_NAME --region $REGION"
+echo "  aws apigatewayv2 delete-api --api-id $API_ID --region $REGION"
+echo "  aws ecr delete-repository --repository-name $ECR_REPO --force --region $REGION"
+echo "  aws dsql delete-cluster --identifier $CLUSTER_ID --region $REGION"
+echo "  aws iam delete-role-policy --role-name $ROLE_NAME --policy-name dsql-connect"
+echo "  aws iam detach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+echo "  aws iam delete-role --role-name $ROLE_NAME"

--- a/rust/lambda-employee-lookup/deploy/zip/cloudformation.yaml
+++ b/rust/lambda-employee-lookup/deploy/zip/cloudformation.yaml
@@ -1,0 +1,123 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >
+  DSQL Employee Lookup - Lambda zip + Aurora DSQL + API Gateway.
+  Pre-requisite: Upload bootstrap.zip to an S3 bucket before deploying.
+
+# USAGE:
+#   1. Upload the zip to S3:
+#      aws s3 cp target/lambda/dsql-employee-lookup/bootstrap.zip \
+#        s3://dsql-employee-lookup-artifacts-<ACCOUNT_ID>/function.zip
+#
+#   2. Deploy:
+#      aws cloudformation deploy \
+#        --template-file cloudformation.yaml \
+#        --stack-name dsql-employee-lookup \
+#        --capabilities CAPABILITY_NAMED_IAM \
+#        --parameter-overrides ArtifactsBucket=dsql-employee-lookup-artifacts-<ACCOUNT_ID>
+
+Parameters:
+  ArtifactsBucket:
+    Type: String
+    Description: S3 bucket containing function.zip
+  ArtifactKey:
+    Type: String
+    Default: function.zip
+    Description: S3 key for the Lambda zip package
+
+Resources:
+  # --- Aurora DSQL ---
+  DsqlCluster:
+    Type: AWS::DSQL::Cluster
+    Properties:
+      DeletionProtectionEnabled: false
+      Tags:
+        - Key: Project
+          Value: dsql-employee-lookup
+
+  # --- IAM Role ---
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: dsql-employee-lookup-role
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: DsqlAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: dsql:DbConnectAdmin
+                Resource: !Sub 'arn:aws:dsql:${AWS::Region}:${AWS::AccountId}:cluster/${DsqlCluster}'
+
+  # --- Lambda (Zip) ---
+  EmployeeLookupFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: dsql-employee-lookup
+      Runtime: provided.al2023
+      Handler: bootstrap
+      Architectures: [arm64]
+      Code:
+        S3Bucket: !Ref ArtifactsBucket
+        S3Key: !Ref ArtifactKey
+      Role: !GetAtt LambdaRole.Arn
+      Timeout: 30
+      MemorySize: 128
+      Environment:
+        Variables:
+          DSQL_ENDPOINT: !GetAtt DsqlCluster.Endpoint
+          DSQL_USER: admin
+          RUST_LOG: info
+
+  # --- API Gateway HTTP API ---
+  HttpApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: dsql-employee-api
+      ProtocolType: HTTP
+
+  LambdaIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref HttpApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt EmployeeLookupFunction.Arn
+      PayloadFormatVersion: '2.0'
+
+  LookupRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref HttpApi
+      RouteKey: POST /lookup
+      Target: !Sub 'integrations/${LambdaIntegration}'
+
+  DefaultStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref HttpApi
+      StageName: '$default'
+      AutoDeploy: true
+
+  LambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref EmployeeLookupFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${HttpApi}/*'
+
+Outputs:
+  ApiEndpoint:
+    Value: !Sub 'https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/lookup'
+  DsqlEndpoint:
+    Value: !GetAtt DsqlCluster.Endpoint
+  DsqlClusterId:
+    Value: !Ref DsqlCluster

--- a/rust/lambda-employee-lookup/deploy/zip/cloudformation.yaml
+++ b/rust/lambda-employee-lookup/deploy/zip/cloudformation.yaml
@@ -6,14 +6,14 @@ Description: >
 # USAGE:
 #   1. Upload the zip to S3:
 #      aws s3 cp target/lambda/dsql-employee-lookup/bootstrap.zip \
-#        s3://dsql-employee-lookup-artifacts-<ACCOUNT_ID>/function.zip
+#        s3://<YOUR_ARTIFACTS_BUCKET>/function.zip
 #
 #   2. Deploy:
 #      aws cloudformation deploy \
 #        --template-file cloudformation.yaml \
 #        --stack-name dsql-employee-lookup \
 #        --capabilities CAPABILITY_NAMED_IAM \
-#        --parameter-overrides ArtifactsBucket=dsql-employee-lookup-artifacts-<ACCOUNT_ID>
+#        --parameter-overrides ArtifactsBucket=<YOUR_ARTIFACTS_BUCKET>
 
 Parameters:
   ArtifactsBucket:

--- a/rust/lambda-employee-lookup/deploy/zip/main.tf
+++ b/rust/lambda-employee-lookup/deploy/zip/main.tf
@@ -95,7 +95,7 @@ resource "aws_apigatewayv2_route" "lookup" {
 
 resource "aws_cloudwatch_log_group" "api_logs" {
   name              = "/aws/apigateway/${var.function_name}-api"
-  retention_in_days = 14
+  retention_in_days = 365
 }
 
 resource "aws_apigatewayv2_stage" "default" {

--- a/rust/lambda-employee-lookup/deploy/zip/main.tf
+++ b/rust/lambda-employee-lookup/deploy/zip/main.tf
@@ -1,0 +1,111 @@
+# =============================================================================
+# DSQL Employee Lookup - Terraform (Zip Deployment)
+# =============================================================================
+# Pre-requisite: Build the zip with cargo-lambda first.
+#
+# USAGE:
+#   terraform init
+#   terraform apply -var="zip_path=../../target/lambda/dsql-employee-lookup/bootstrap.zip"
+# =============================================================================
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}
+
+provider "aws" { region = var.region }
+
+variable "region"        { default = "us-east-1" }
+variable "zip_path"      { type = string description = "Path to bootstrap.zip" }
+variable "function_name" { default = "dsql-employee-lookup" }
+
+data "aws_caller_identity" "current" {}
+
+# --- Aurora DSQL ---
+resource "aws_dsql_cluster" "main" {
+  deletion_protection_enabled = false
+  tags = { Project = "dsql-employee-lookup" }
+}
+
+# --- IAM Role ---
+resource "aws_iam_role" "lambda" {
+  name = "${var.function_name}-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{ Effect = "Allow", Principal = { Service = "lambda.amazonaws.com" }, Action = "sts:AssumeRole" }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "basic" {
+  role       = aws_iam_role.lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "dsql" {
+  name = "dsql-connect"
+  role = aws_iam_role.lambda.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{ Effect = "Allow", Action = "dsql:DbConnectAdmin", Resource = "arn:aws:dsql:${var.region}:${data.aws_caller_identity.current.account_id}:cluster/${aws_dsql_cluster.main.id}" }]
+  })
+}
+
+# --- Lambda (Zip) ---
+resource "aws_lambda_function" "main" {
+  function_name    = var.function_name
+  runtime          = "provided.al2023"
+  handler          = "bootstrap"
+  architectures    = ["arm64"]
+  filename         = var.zip_path
+  source_code_hash = filebase64sha256(var.zip_path)
+  role             = aws_iam_role.lambda.arn
+  timeout          = 30
+  memory_size      = 128
+  environment {
+    variables = {
+      DSQL_ENDPOINT = aws_dsql_cluster.main.endpoint
+      DSQL_USER     = "admin"
+      RUST_LOG      = "info"
+    }
+  }
+  depends_on = [aws_iam_role_policy_attachment.basic, aws_iam_role_policy.dsql]
+}
+
+# --- API Gateway ---
+resource "aws_apigatewayv2_api" "main" {
+  name          = "${var.function_name}-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.main.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.main.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "lookup" {
+  api_id    = aws_apigatewayv2_api.main.id
+  route_key = "POST /lookup"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.main.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+resource "aws_lambda_permission" "apigw" {
+  function_name = aws_lambda_function.main.function_name
+  action        = "lambda:InvokeFunction"
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.main.execution_arn}/*"
+}
+
+# --- Outputs ---
+output "api_endpoint"    { value = "${aws_apigatewayv2_api.main.api_endpoint}/lookup" }
+output "dsql_endpoint"   { value = aws_dsql_cluster.main.endpoint }
+output "dsql_cluster_id" { value = aws_dsql_cluster.main.id }

--- a/rust/lambda-employee-lookup/deploy/zip/main.tf
+++ b/rust/lambda-employee-lookup/deploy/zip/main.tf
@@ -90,12 +90,31 @@ resource "aws_apigatewayv2_route" "lookup" {
   api_id    = aws_apigatewayv2_api.main.id
   route_key = "POST /lookup"
   target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+  authorization_type = "AWS_IAM"
+}
+
+resource "aws_cloudwatch_log_group" "api_logs" {
+  name              = "/aws/apigateway/${var.function_name}-api"
+  retention_in_days = 14
 }
 
 resource "aws_apigatewayv2_stage" "default" {
   api_id      = aws_apigatewayv2_api.main.id
   name        = "$default"
   auto_deploy = true
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_logs.arn
+    format = jsonencode({
+      requestId      = "$context.requestId"
+      ip             = "$context.identity.sourceIp"
+      requestTime    = "$context.requestTime"
+      httpMethod     = "$context.httpMethod"
+      routeKey       = "$context.routeKey"
+      status         = "$context.status"
+      responseLength = "$context.responseLength"
+    })
+  }
 }
 
 resource "aws_lambda_permission" "apigw" {

--- a/rust/lambda-employee-lookup/deploy/zip/setup.sh
+++ b/rust/lambda-employee-lookup/deploy/zip/setup.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# =============================================================================
+# DSQL Employee Lookup - Zip Deployment (Linux)
+# =============================================================================
+# Deploys Lambda as a .zip package (250MB unzipped limit).
+# Run this on a Linux machine or in a Linux CI/CD pipeline.
+#
+# IMPORTANT: Requires [profile.release] strip=true and lto=true in Cargo.toml
+# to keep binary under 250MB. If your binary exceeds 250MB, use the container
+# approach instead (../container/setup.sh).
+#
+# Prerequisites:
+#   - AWS CLI v2 configured with credentials
+#   - Rust 1.84+ and cargo-lambda installed
+#   - jq installed
+#
+# Usage:
+#   chmod +x setup.sh
+#   ./setup.sh
+# =============================================================================
+
+set -euo pipefail
+
+REGION="us-east-1"
+FUNCTION_NAME="dsql-employee-lookup"
+ROLE_NAME="dsql-employee-lookup-role"
+API_NAME="dsql-employee-api"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+echo "============================================"
+echo "DSQL Employee Lookup - Zip Deployment"
+echo "============================================"
+echo "Region:  $REGION"
+echo "Account: $ACCOUNT_ID"
+echo ""
+
+# =============================================================================
+# STEP 1: Create Aurora DSQL cluster
+# =============================================================================
+echo ">>> Step 1: Aurora DSQL cluster..."
+
+read -p "    Do you already have a DSQL cluster? (y/N): " has_cluster
+if [[ "$has_cluster" == "y" || "$has_cluster" == "Y" ]]; then
+  read -p "    Enter cluster endpoint: " CLUSTER_ENDPOINT
+  CLUSTER_ID=$(echo $CLUSTER_ENDPOINT | cut -d'.' -f1)
+else
+  echo "    Creating cluster..."
+  CLUSTER_OUTPUT=$(aws dsql create-cluster \
+    --no-deletion-protection-enabled \
+    --region $REGION \
+    --output json)
+
+  CLUSTER_ID=$(echo $CLUSTER_OUTPUT | jq -r '.identifier')
+  CLUSTER_ENDPOINT=$(echo $CLUSTER_OUTPUT | jq -r '.endpoint')
+
+  echo "    Cluster ID: $CLUSTER_ID"
+  echo "    Endpoint:   $CLUSTER_ENDPOINT"
+  echo "    Waiting for cluster to become ACTIVE..."
+
+  while true; do
+    STATUS=$(aws dsql get-cluster --identifier $CLUSTER_ID --region $REGION --query 'status' --output text 2>/dev/null || echo "CREATING")
+    if [ "$STATUS" == "ACTIVE" ]; then break; fi
+    echo "    Status: $STATUS - waiting..."
+    sleep 10
+  done
+  echo "    Cluster is ACTIVE!"
+fi
+echo ""
+
+# =============================================================================
+# STEP 2: Build Rust binary as zip
+# =============================================================================
+echo ">>> Step 2: Building Rust Lambda binary (.zip)..."
+
+cargo lambda build --release --arm64 --output-format zip
+
+ZIP_PATH="../../target/lambda/${FUNCTION_NAME}/bootstrap.zip"
+
+if [ ! -f "$ZIP_PATH" ]; then
+  echo "    ERROR: Zip not found at $ZIP_PATH"
+  echo "    Trying alternate location..."
+  ZIP_PATH=$(find ../../target -name "bootstrap.zip" -print -quit)
+fi
+
+ZIP_SIZE=$(stat -c%s "$ZIP_PATH" 2>/dev/null || stat -f%z "$ZIP_PATH")
+echo "    Zip: $ZIP_PATH ($(echo "scale=1; $ZIP_SIZE/1048576" | bc) MB)"
+
+# Check if unzipped size exceeds Lambda limit
+UNZIPPED_SIZE=$(unzip -l "$ZIP_PATH" | tail -1 | awk '{print $1}')
+if [ "$UNZIPPED_SIZE" -gt 262144000 ]; then
+  echo ""
+  echo "    WARNING: Unzipped size ($UNZIPPED_SIZE bytes) exceeds Lambda's 250MB limit!"
+  echo "    Use the container approach instead: ../container/setup.sh"
+  echo ""
+  read -p "    Continue anyway? (y/N): " force_continue
+  if [[ "$force_continue" != "y" && "$force_continue" != "Y" ]]; then
+    echo "    Aborted. Use ../container/setup.sh instead."
+    exit 1
+  fi
+fi
+echo ""
+
+# =============================================================================
+# STEP 3: Create IAM Role
+# =============================================================================
+echo ">>> Step 3: Creating IAM role..."
+
+aws iam create-role \
+  --role-name $ROLE_NAME \
+  --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+  --output text --query 'Role.Arn' 2>/dev/null || echo "    Role already exists"
+
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+
+aws iam attach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole 2>/dev/null || true
+
+aws iam put-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-name dsql-connect \
+  --policy-document "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"dsql:DbConnectAdmin\",\"Resource\":\"arn:aws:dsql:${REGION}:${ACCOUNT_ID}:cluster/${CLUSTER_ID}\"}]}"
+
+echo "    IAM role configured. Waiting for propagation..."
+sleep 10
+echo ""
+
+# =============================================================================
+# STEP 4: Create Lambda function (zip)
+# =============================================================================
+echo ">>> Step 4: Creating Lambda function..."
+
+aws lambda create-function \
+  --function-name $FUNCTION_NAME \
+  --runtime provided.al2023 \
+  --handler bootstrap \
+  --architectures arm64 \
+  --role $ROLE_ARN \
+  --zip-file fileb://$ZIP_PATH \
+  --timeout 30 \
+  --memory-size 128 \
+  --environment "Variables={DSQL_ENDPOINT=$CLUSTER_ENDPOINT,DSQL_USER=admin,RUST_LOG=info}" \
+  --region $REGION \
+  --output text --query 'FunctionArn'
+
+echo "    Waiting for function to be active..."
+aws lambda wait function-active-v2 --function-name $FUNCTION_NAME --region $REGION
+echo "    Lambda deployed!"
+echo ""
+
+# =============================================================================
+# STEP 5: Create API Gateway HTTP API
+# =============================================================================
+echo ">>> Step 5: Creating API Gateway..."
+
+API_OUTPUT=$(aws apigatewayv2 create-api \
+  --name $API_NAME --protocol-type HTTP --region $REGION --output json)
+API_ID=$(echo $API_OUTPUT | jq -r '.ApiId')
+API_ENDPOINT=$(echo $API_OUTPUT | jq -r '.ApiEndpoint')
+
+FUNCTION_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+
+INTEGRATION_ID=$(aws apigatewayv2 create-integration \
+  --api-id $API_ID --integration-type AWS_PROXY \
+  --integration-uri $FUNCTION_ARN --payload-format-version "2.0" \
+  --region $REGION --output text --query 'IntegrationId')
+
+aws apigatewayv2 create-route --api-id $API_ID \
+  --route-key "POST /lookup" --target "integrations/$INTEGRATION_ID" \
+  --region $REGION > /dev/null
+
+aws apigatewayv2 create-stage --api-id $API_ID \
+  --stage-name '$default' --auto-deploy --region $REGION > /dev/null
+
+aws lambda add-permission --function-name $FUNCTION_NAME \
+  --statement-id apigateway-invoke --action lambda:InvokeFunction \
+  --principal apigateway.amazonaws.com \
+  --source-arn "arn:aws:execute-api:${REGION}:${ACCOUNT_ID}:${API_ID}/*" \
+  --region $REGION > /dev/null
+
+echo "    API Gateway configured!"
+echo ""
+
+# =============================================================================
+# DONE
+# =============================================================================
+echo "============================================"
+echo "SETUP COMPLETE!"
+echo "============================================"
+echo ""
+echo "  DSQL Endpoint: $CLUSTER_ENDPOINT"
+echo "  API Endpoint:  ${API_ENDPOINT}/lookup"
+echo ""
+echo "Test: curl -X POST ${API_ENDPOINT}/lookup -H 'Content-Type: application/json' -d '{\"name\":\"Alice\"}'"
+echo ""
+echo "Teardown:"
+echo "  aws lambda delete-function --function-name $FUNCTION_NAME --region $REGION"
+echo "  aws apigatewayv2 delete-api --api-id $API_ID --region $REGION"
+echo "  aws dsql delete-cluster --identifier $CLUSTER_ID --region $REGION"
+echo "  aws iam delete-role-policy --role-name $ROLE_NAME --policy-name dsql-connect"
+echo "  aws iam detach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+echo "  aws iam delete-role --role-name $ROLE_NAME"

--- a/rust/lambda-employee-lookup/seed.sql
+++ b/rust/lambda-employee-lookup/seed.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- DSQL Employee Lookup - Database Setup & Seed Data
+-- =============================================================================
+-- Run this SQL after connecting to your DSQL cluster as admin.
+--
+-- Connect via Query Editor in the console, or via psql:
+--   TOKEN=$(aws dsql generate-db-connect-admin-auth-token \
+--     --hostname <YOUR_ENDPOINT> --region us-east-1)
+--   PGPASSWORD=$TOKEN psql "host=<YOUR_ENDPOINT> port=5432 dbname=postgres user=admin sslmode=require"
+-- =============================================================================
+
+-- Step 1: Create the application role with least privilege
+CREATE ROLE app_readonly WITH LOGIN;
+
+-- Step 2: Grant IAM authentication to your Lambda execution role
+-- Replace <ACCOUNT_ID> with your AWS account ID
+AWS IAM GRANT app_readonly TO 'arn:aws:iam::<ACCOUNT_ID>:role/dsql-employee-lookup-role';
+
+-- Step 3: Create the employees table
+CREATE TABLE IF NOT EXISTS employees (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    name TEXT NOT NULL,
+    email TEXT NOT NULL,
+    department TEXT NOT NULL,
+    title TEXT NOT NULL,
+    hire_date DATE NOT NULL
+);
+
+-- Step 4: Insert sample data (using AWS documentation patterns)
+INSERT INTO employees (name, email, department, title, hire_date) VALUES
+  ('John Doe', 'jdoe@example.com', 'Engineering', 'Software Engineer', '2022-01-15'),
+  ('Jane Doe', 'jane.doe@example.com', 'Product', 'Product Manager', '2021-06-01'),
+  ('Carlos Garcia', 'cgarcia@example.com', 'Engineering', 'Senior Engineer', '2020-11-20'),
+  ('Alice Johnson', 'alice@example.com', 'Engineering', 'Staff Engineer', '2019-03-15'),
+  ('Bob Smith', 'bob.smith@example.com', 'Sales', 'Account Executive', '2023-02-28');
+
+-- Step 5: Grant only SELECT on the employees table to the app role
+GRANT SELECT ON employees TO app_readonly;
+
+-- Verify: Check the data
+SELECT * FROM employees ORDER BY name;

--- a/rust/lambda-employee-lookup/setup-docker.sh
+++ b/rust/lambda-employee-lookup/setup-docker.sh
@@ -1,0 +1,273 @@
+#!/bin/bash
+# =============================================================================
+# DSQL Employee Lookup - Test Environment Setup (Docker)
+# =============================================================================
+# Deploys: Aurora DSQL + Lambda (container image) + API Gateway
+#
+# Prerequisites:
+#   - AWS CLI v2 configured with credentials
+#   - Docker Desktop running
+#   - jq installed (brew install jq)
+#
+# Usage:
+#   chmod +x setup-docker.sh
+#   ./setup-docker.sh
+# =============================================================================
+
+set -euo pipefail
+
+REGION="us-east-1"
+FUNCTION_NAME="dsql-employee-lookup"
+ROLE_NAME="dsql-employee-lookup-role"
+API_NAME="dsql-employee-api"
+ECR_REPO="${FUNCTION_NAME}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${ECR_REPO}"
+
+echo "============================================"
+echo "DSQL Employee Lookup - Test Environment Setup"
+echo "============================================"
+echo "Region: $REGION"
+echo "Account: $ACCOUNT_ID"
+echo "Container: Docker"
+echo ""
+
+# =============================================================================
+# STEP 1: Create Aurora DSQL cluster
+# =============================================================================
+echo ">>> Step 1: Aurora DSQL cluster..."
+
+read -p "    Do you already have a DSQL cluster? (y/N): " has_cluster
+if [[ "$has_cluster" == "y" || "$has_cluster" == "Y" ]]; then
+  read -p "    Enter cluster endpoint: " CLUSTER_ENDPOINT
+  CLUSTER_ID=$(echo $CLUSTER_ENDPOINT | cut -d'.' -f1)
+else
+  echo "    Creating cluster..."
+  CLUSTER_OUTPUT=$(aws dsql create-cluster \
+    --no-deletion-protection-enabled \
+    --region $REGION \
+    --output json)
+
+  CLUSTER_ID=$(echo $CLUSTER_OUTPUT | jq -r '.identifier')
+  CLUSTER_ENDPOINT=$(echo $CLUSTER_OUTPUT | jq -r '.endpoint')
+
+  echo "    Cluster ID: $CLUSTER_ID"
+  echo "    Endpoint: $CLUSTER_ENDPOINT"
+  echo "    Waiting for cluster to become ACTIVE..."
+
+  while true; do
+    STATUS=$(aws dsql get-cluster --identifier $CLUSTER_ID --region $REGION --query 'status' --output text 2>/dev/null || echo "CREATING")
+    if [ "$STATUS" == "ACTIVE" ]; then
+      break
+    fi
+    echo "    Status: $STATUS - waiting..."
+    sleep 10
+  done
+  echo "    Cluster is ACTIVE!"
+fi
+echo ""
+
+# =============================================================================
+# STEP 2: Build Rust binary inside Docker container
+# =============================================================================
+echo ">>> Step 2: Building Rust Lambda binary (Docker container)..."
+
+docker run --rm -v $(pwd):/code -w /code \
+  public.ecr.aws/sam/build-provided.al2023:latest-arm64 \
+  bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+  source \$HOME/.cargo/env && \
+  pip3 install cargo-lambda && \
+  cargo lambda build --release --arm64 --output-format binary"
+
+echo "    Binary built!"
+echo ""
+
+# =============================================================================
+# STEP 3: Build container image and push to ECR
+# =============================================================================
+echo ">>> Step 3: Building and pushing container image to ECR..."
+
+# Create ECR repo (ignore if exists)
+aws ecr create-repository \
+  --repository-name $ECR_REPO \
+  --region $REGION 2>/dev/null || echo "    ECR repo already exists"
+
+# Login to ECR
+aws ecr get-login-password --region $REGION | \
+  docker login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
+
+# Build container image
+docker build --platform linux/arm64 -t ${ECR_URI}:latest .
+
+# Push to ECR
+docker push ${ECR_URI}:latest
+
+echo "    Image pushed: ${ECR_URI}:latest"
+echo ""
+
+# =============================================================================
+# STEP 4: Create IAM Role for Lambda
+# =============================================================================
+echo ">>> Step 4: Creating IAM role..."
+
+cat > /tmp/trust-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+
+aws iam create-role \
+  --role-name $ROLE_NAME \
+  --assume-role-policy-document file:///tmp/trust-policy.json \
+  --output text --query 'Role.Arn' 2>/dev/null || echo "    Role already exists"
+
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+
+aws iam attach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole 2>/dev/null || true
+
+cat > /tmp/dsql-policy.json << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "dsql:DbConnectAdmin",
+    "Resource": "arn:aws:dsql:${REGION}:${ACCOUNT_ID}:cluster/${CLUSTER_ID}"
+  }]
+}
+EOF
+
+aws iam put-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-name dsql-connect \
+  --policy-document file:///tmp/dsql-policy.json
+
+echo "    IAM role configured"
+echo "    Waiting for role propagation..."
+sleep 10
+echo ""
+
+# =============================================================================
+# STEP 5: Create Lambda function from container image
+# =============================================================================
+echo ">>> Step 5: Creating Lambda function..."
+
+aws lambda create-function \
+  --function-name $FUNCTION_NAME \
+  --package-type Image \
+  --code ImageUri=${ECR_URI}:latest \
+  --role $ROLE_ARN \
+  --architectures arm64 \
+  --timeout 30 \
+  --memory-size 128 \
+  --environment "Variables={DSQL_ENDPOINT=$CLUSTER_ENDPOINT,DSQL_USER=admin,RUST_LOG=info}" \
+  --region $REGION \
+  --output text --query 'FunctionArn'
+
+echo "    Waiting for function to be active..."
+aws lambda wait function-active-v2 \
+  --function-name $FUNCTION_NAME \
+  --region $REGION
+echo "    Lambda function deployed!"
+echo ""
+
+# =============================================================================
+# STEP 6: Create API Gateway HTTP API
+# =============================================================================
+echo ">>> Step 6: Creating API Gateway..."
+
+API_OUTPUT=$(aws apigatewayv2 create-api \
+  --name $API_NAME \
+  --protocol-type HTTP \
+  --region $REGION \
+  --output json)
+
+API_ID=$(echo $API_OUTPUT | jq -r '.ApiId')
+API_ENDPOINT=$(echo $API_OUTPUT | jq -r '.ApiEndpoint')
+
+FUNCTION_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+
+INTEGRATION_ID=$(aws apigatewayv2 create-integration \
+  --api-id $API_ID \
+  --integration-type AWS_PROXY \
+  --integration-uri $FUNCTION_ARN \
+  --payload-format-version "2.0" \
+  --region $REGION \
+  --output text --query 'IntegrationId')
+
+aws apigatewayv2 create-route \
+  --api-id $API_ID \
+  --route-key "POST /lookup" \
+  --target "integrations/$INTEGRATION_ID" \
+  --region $REGION > /dev/null
+
+aws apigatewayv2 create-stage \
+  --api-id $API_ID \
+  --stage-name '$default' \
+  --auto-deploy \
+  --region $REGION > /dev/null
+
+aws lambda add-permission \
+  --function-name $FUNCTION_NAME \
+  --statement-id apigateway-invoke \
+  --action lambda:InvokeFunction \
+  --principal apigateway.amazonaws.com \
+  --source-arn "arn:aws:execute-api:${REGION}:${ACCOUNT_ID}:${API_ID}/*" \
+  --region $REGION > /dev/null
+
+echo "    API Gateway configured!"
+echo ""
+
+# =============================================================================
+# DONE
+# =============================================================================
+echo "============================================"
+echo "SETUP COMPLETE!"
+echo "============================================"
+echo ""
+echo "Resources:"
+echo "  DSQL Cluster:    $CLUSTER_ID"
+echo "  DSQL Endpoint:   $CLUSTER_ENDPOINT"
+echo "  ECR Image:       ${ECR_URI}:latest"
+echo "  Lambda Function: $FUNCTION_NAME"
+echo "  API Gateway:     $API_ID"
+echo "  API Endpoint:    $API_ENDPOINT"
+echo ""
+echo "NEXT STEPS:"
+echo ""
+echo "  1. Seed the database (connect via Query Editor or psql, run seed.sql)"
+echo ""
+echo "  2. Test the API:"
+echo "     curl -X POST ${API_ENDPOINT}/lookup \\"
+echo "       -H 'Content-Type: application/json' \\"
+echo "       -d '{\"name\": \"Alice\"}'"
+echo ""
+echo "  3. Teardown when done:"
+echo "     aws lambda delete-function --function-name $FUNCTION_NAME --region $REGION"
+echo "     aws apigatewayv2 delete-api --api-id $API_ID --region $REGION"
+echo "     aws ecr delete-repository --repository-name $ECR_REPO --force --region $REGION"
+echo "     aws dsql delete-cluster --identifier $CLUSTER_ID --region $REGION"
+echo "     aws iam delete-role-policy --role-name $ROLE_NAME --policy-name dsql-connect"
+echo "     aws iam detach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+echo "     aws iam delete-role --role-name $ROLE_NAME"
+echo ""
+
+cat > env.sh << EOF
+export REGION="$REGION"
+export CLUSTER_ID="$CLUSTER_ID"
+export CLUSTER_ENDPOINT="$CLUSTER_ENDPOINT"
+export FUNCTION_NAME="$FUNCTION_NAME"
+export ROLE_NAME="$ROLE_NAME"
+export API_ID="$API_ID"
+export API_ENDPOINT="$API_ENDPOINT"
+export ECR_URI="$ECR_URI"
+export ACCOUNT_ID="$ACCOUNT_ID"
+EOF
+
+echo "Environment saved to env.sh"

--- a/rust/lambda-employee-lookup/setup-finch.sh
+++ b/rust/lambda-employee-lookup/setup-finch.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+# =============================================================================
+# DSQL Employee Lookup - Test Environment Setup
+# =============================================================================
+# Deploys: Aurora DSQL + Lambda (container image) + API Gateway
+#
+# Prerequisites:
+#   - AWS CLI v2 configured with credentials
+#   - Finch running (finch vm start)
+#   - jq installed (brew install jq)
+#
+# Usage:
+#   chmod +x setup.sh
+#   ./setup.sh
+# =============================================================================
+
+set -euo pipefail
+
+REGION="us-east-1"
+FUNCTION_NAME="dsql-employee-lookup"
+ROLE_NAME="dsql-employee-lookup-role"
+API_NAME="dsql-employee-api"
+ECR_REPO="${FUNCTION_NAME}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${ECR_REPO}"
+
+echo "============================================"
+echo "DSQL Employee Lookup - Test Environment Setup"
+echo "============================================"
+echo "Region: $REGION"
+echo "Account: $ACCOUNT_ID"
+echo ""
+
+# =============================================================================
+# STEP 1: Create Aurora DSQL cluster
+# =============================================================================
+echo ">>> Step 1: Aurora DSQL cluster..."
+
+read -p "    Do you already have a DSQL cluster? (y/N): " has_cluster
+if [[ "$has_cluster" == "y" || "$has_cluster" == "Y" ]]; then
+  read -p "    Enter cluster endpoint: " CLUSTER_ENDPOINT
+  CLUSTER_ID=$(echo $CLUSTER_ENDPOINT | cut -d'.' -f1)
+else
+  echo "    Creating cluster..."
+  CLUSTER_OUTPUT=$(aws dsql create-cluster \
+    --no-deletion-protection-enabled \
+    --region $REGION \
+    --output json)
+
+  CLUSTER_ID=$(echo $CLUSTER_OUTPUT | jq -r '.identifier')
+  CLUSTER_ENDPOINT=$(echo $CLUSTER_OUTPUT | jq -r '.endpoint')
+
+  echo "    Cluster ID: $CLUSTER_ID"
+  echo "    Endpoint: $CLUSTER_ENDPOINT"
+  echo "    Waiting for cluster to become ACTIVE..."
+
+  while true; do
+    STATUS=$(aws dsql get-cluster --identifier $CLUSTER_ID --region $REGION --query 'status' --output text 2>/dev/null || echo "CREATING")
+    if [ "$STATUS" == "ACTIVE" ]; then
+      break
+    fi
+    echo "    Status: $STATUS - waiting..."
+    sleep 10
+  done
+  echo "    Cluster is ACTIVE!"
+fi
+echo ""
+
+# =============================================================================
+# STEP 2: Build Rust binary inside Finch container
+# =============================================================================
+echo ">>> Step 2: Building Rust Lambda binary (Finch container)..."
+
+finch run --rm -v $(pwd):/code -w /code \
+  public.ecr.aws/sam/build-provided.al2023:latest-arm64 \
+  bash -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && \
+  source \$HOME/.cargo/env && \
+  pip3 install cargo-lambda && \
+  cargo lambda build --release --arm64 --output-format binary"
+
+echo "    Binary built!"
+echo ""
+
+# =============================================================================
+# STEP 3: Build container image and push to ECR
+# =============================================================================
+echo ">>> Step 3: Building and pushing container image to ECR..."
+
+# Create ECR repo (ignore if exists)
+aws ecr create-repository \
+  --repository-name $ECR_REPO \
+  --region $REGION 2>/dev/null || echo "    ECR repo already exists"
+
+# Login to ECR
+aws ecr get-login-password --region $REGION | \
+  finch login --username AWS --password-stdin ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com
+
+# Build container image
+finch build --platform linux/arm64 -t ${ECR_URI}:latest .
+
+# Push to ECR
+finch push ${ECR_URI}:latest
+
+echo "    Image pushed: ${ECR_URI}:latest"
+echo ""
+
+# =============================================================================
+# STEP 4: Create IAM Role for Lambda
+# =============================================================================
+echo ">>> Step 4: Creating IAM role..."
+
+cat > /tmp/trust-policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "lambda.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}
+EOF
+
+aws iam create-role \
+  --role-name $ROLE_NAME \
+  --assume-role-policy-document file:///tmp/trust-policy.json \
+  --output text --query 'Role.Arn' 2>/dev/null || echo "    Role already exists"
+
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+
+aws iam attach-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole 2>/dev/null || true
+
+cat > /tmp/dsql-policy.json << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": "dsql:DbConnectAdmin",
+    "Resource": "arn:aws:dsql:${REGION}:${ACCOUNT_ID}:cluster/${CLUSTER_ID}"
+  }]
+}
+EOF
+
+aws iam put-role-policy \
+  --role-name $ROLE_NAME \
+  --policy-name dsql-connect \
+  --policy-document file:///tmp/dsql-policy.json
+
+echo "    IAM role configured"
+echo "    Waiting for role propagation..."
+sleep 10
+echo ""
+
+# =============================================================================
+# STEP 5: Create Lambda function from container image
+# =============================================================================
+echo ">>> Step 5: Creating Lambda function..."
+
+aws lambda create-function \
+  --function-name $FUNCTION_NAME \
+  --package-type Image \
+  --code ImageUri=${ECR_URI}:latest \
+  --role $ROLE_ARN \
+  --architectures arm64 \
+  --timeout 30 \
+  --memory-size 128 \
+  --environment "Variables={DSQL_ENDPOINT=$CLUSTER_ENDPOINT,DSQL_USER=admin,RUST_LOG=info}" \
+  --region $REGION \
+  --output text --query 'FunctionArn'
+
+echo "    Waiting for function to be active..."
+aws lambda wait function-active-v2 \
+  --function-name $FUNCTION_NAME \
+  --region $REGION
+echo "    Lambda function deployed!"
+echo ""
+
+# =============================================================================
+# STEP 6: Create API Gateway HTTP API
+# =============================================================================
+echo ">>> Step 6: Creating API Gateway..."
+
+API_OUTPUT=$(aws apigatewayv2 create-api \
+  --name $API_NAME \
+  --protocol-type HTTP \
+  --region $REGION \
+  --output json)
+
+API_ID=$(echo $API_OUTPUT | jq -r '.ApiId')
+API_ENDPOINT=$(echo $API_OUTPUT | jq -r '.ApiEndpoint')
+
+FUNCTION_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${FUNCTION_NAME}"
+
+INTEGRATION_ID=$(aws apigatewayv2 create-integration \
+  --api-id $API_ID \
+  --integration-type AWS_PROXY \
+  --integration-uri $FUNCTION_ARN \
+  --payload-format-version "2.0" \
+  --region $REGION \
+  --output text --query 'IntegrationId')
+
+aws apigatewayv2 create-route \
+  --api-id $API_ID \
+  --route-key "POST /lookup" \
+  --target "integrations/$INTEGRATION_ID" \
+  --region $REGION > /dev/null
+
+aws apigatewayv2 create-stage \
+  --api-id $API_ID \
+  --stage-name '$default' \
+  --auto-deploy \
+  --region $REGION > /dev/null
+
+aws lambda add-permission \
+  --function-name $FUNCTION_NAME \
+  --statement-id apigateway-invoke \
+  --action lambda:InvokeFunction \
+  --principal apigateway.amazonaws.com \
+  --source-arn "arn:aws:execute-api:${REGION}:${ACCOUNT_ID}:${API_ID}/*" \
+  --region $REGION > /dev/null
+
+echo "    API Gateway configured!"
+echo ""
+
+# =============================================================================
+# DONE
+# =============================================================================
+echo "============================================"
+echo "SETUP COMPLETE!"
+echo "============================================"
+echo ""
+echo "Resources:"
+echo "  DSQL Cluster:    $CLUSTER_ID"
+echo "  DSQL Endpoint:   $CLUSTER_ENDPOINT"
+echo "  ECR Image:       ${ECR_URI}:latest"
+echo "  Lambda Function: $FUNCTION_NAME"
+echo "  API Gateway:     $API_ID"
+echo "  API Endpoint:    $API_ENDPOINT"
+echo ""
+echo "NEXT STEPS:"
+echo ""
+echo "  1. Seed the database (connect via Query Editor or psql, run seed.sql)"
+echo ""
+echo "  2. Test the API:"
+echo "     curl -X POST ${API_ENDPOINT}/lookup \\"
+echo "       -H 'Content-Type: application/json' \\"
+echo "       -d '{\"name\": \"Alice\"}'"
+echo ""
+echo "  3. Teardown when done:"
+echo "     aws lambda delete-function --function-name $FUNCTION_NAME --region $REGION"
+echo "     aws apigatewayv2 delete-api --api-id $API_ID --region $REGION"
+echo "     aws ecr delete-repository --repository-name $ECR_REPO --force --region $REGION"
+echo "     aws dsql delete-cluster --identifier $CLUSTER_ID --region $REGION"
+echo "     aws iam delete-role-policy --role-name $ROLE_NAME --policy-name dsql-connect"
+echo "     aws iam detach-role-policy --role-name $ROLE_NAME --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+echo "     aws iam delete-role --role-name $ROLE_NAME"
+echo ""
+
+cat > env.sh << EOF
+export REGION="$REGION"
+export CLUSTER_ID="$CLUSTER_ID"
+export CLUSTER_ENDPOINT="$CLUSTER_ENDPOINT"
+export FUNCTION_NAME="$FUNCTION_NAME"
+export ROLE_NAME="$ROLE_NAME"
+export API_ID="$API_ID"
+export API_ENDPOINT="$API_ENDPOINT"
+export ECR_URI="$ECR_URI"
+export ACCOUNT_ID="$ACCOUNT_ID"
+EOF
+
+echo "Environment saved to env.sh"

--- a/rust/lambda-employee-lookup/src/main.rs
+++ b/rust/lambda-employee-lookup/src/main.rs
@@ -1,0 +1,151 @@
+use anyhow::Result;
+use aurora_dsql_sqlx_connector::DsqlConnectOptions;
+use lambda_http::{run, service_fn, Body, Error, Request, Response};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::{Executor, PgPool, Row};
+use std::env;
+use std::sync::OnceLock;
+use tracing::{error, info};
+
+// Global connection pool — initialized once, reused across Lambda invocations
+static POOL: OnceLock<PgPool> = OnceLock::new();
+
+#[derive(Deserialize, Default)]
+struct LookupRequest {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Serialize)]
+struct Employee {
+    id: String,
+    name: String,
+    email: String,
+    department: String,
+    title: String,
+    hire_date: String,
+}
+
+/// Initialize the DSQL connection pool using aurora-dsql-sqlx-connector.
+///
+/// The connector handles:
+/// - IAM token generation and automatic background refresh
+/// - TLS configuration for DSQL
+/// - Connection health checks
+///
+/// PgPoolOptions configures:
+/// - max_connections: max concurrent connections in the pool
+/// - after_connect: sets the search_path on each new connection
+async fn init_pool() -> Result<PgPool> {
+    let endpoint = env::var("DSQL_ENDPOINT").expect("DSQL_ENDPOINT required");
+    let user = env::var("DSQL_USER").unwrap_or_else(|_| "admin".into());
+
+    let conn_str = format!("postgres://{}@{}/postgres", user, endpoint);
+    let config = DsqlConnectOptions::from_connection_string(&conn_str)?;
+
+    let pool = aurora_dsql_sqlx_connector::pool::connect_with(
+        &config,
+        PgPoolOptions::new()
+            .max_connections(5)
+            .after_connect(|conn, _meta| {
+                Box::pin(async move {
+                    conn.execute("SET search_path = 'public'").await?;
+                    Ok(())
+                })
+            }),
+    )
+    .await?;
+
+    info!("DSQL connection pool initialized (max_connections=5)");
+    Ok(pool)
+}
+
+/// Get or initialize the global pool
+async fn get_pool() -> Result<&'static PgPool> {
+    if let Some(pool) = POOL.get() {
+        return Ok(pool);
+    }
+    let pool = init_pool().await?;
+    Ok(POOL.get_or_init(|| pool))
+}
+
+/// Query employees from the database
+async fn query_employees(pool: &PgPool, name_filter: &str) -> Result<Vec<Employee>> {
+    let rows = if name_filter.is_empty() {
+        info!("Fetching all employees");
+        sqlx::query(
+            "SELECT id::text, name, email, department, title, \
+             hire_date::text FROM employees ORDER BY name",
+        )
+        .fetch_all(pool)
+        .await?
+    } else {
+        info!(name = %name_filter, "Searching employees");
+        let pattern = format!("%{name_filter}%");
+        sqlx::query(
+            "SELECT id::text, name, email, department, title, \
+             hire_date::text FROM employees \
+             WHERE LOWER(name) LIKE LOWER($1) ORDER BY name",
+        )
+        .bind(&pattern)
+        .fetch_all(pool)
+        .await?
+    };
+
+    Ok(rows
+        .iter()
+        .map(|row| Employee {
+            id: row.get(0),
+            name: row.get(1),
+            email: row.get(2),
+            department: row.get(3),
+            title: row.get(4),
+            hire_date: row.get(5),
+        })
+        .collect())
+}
+
+async fn handler(event: Request) -> Result<Response<Body>, Error> {
+    let pool = get_pool().await.map_err(|e| {
+        error!(error = %e, "Pool init failed");
+        Error::from(e.to_string())
+    })?;
+
+    // Parse the JSON body into our query struct
+    let query: LookupRequest = match event.body() {
+        Body::Text(t) => serde_json::from_str(t).unwrap_or_default(),
+        Body::Binary(b) => serde_json::from_slice(b).unwrap_or_default(),
+        Body::Empty => LookupRequest::default(),
+    };
+
+    let filter = query.name.unwrap_or_default();
+
+    match query_employees(pool, &filter).await {
+        Ok(employees) => {
+            info!(count = employees.len(), "Query complete");
+            Ok(Response::builder()
+                .status(200)
+                .header("Content-Type", "application/json")
+                .body(Body::Text(serde_json::to_string(&json!({
+                    "count": employees.len(),
+                    "employees": employees,
+                }))?))?)
+        }
+        Err(e) => {
+            error!(error = %e, "Query failed");
+            Ok(Response::builder()
+                .status(500)
+                .header("Content-Type", "application/json")
+                .body(Body::Text(serde_json::to_string(&json!({"error": e.to_string()}))?))?)
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    lambda_http::tracing::init_default_subscriber();
+    info!("Starting dsql-employee-lookup Lambda");
+    run(service_fn(handler)).await
+}

--- a/rust/lambda-employee-lookup/test-api.sh
+++ b/rust/lambda-employee-lookup/test-api.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# =============================================================================
+# DSQL Employee Lookup - API Test Script
+# =============================================================================
+# Run this after setup.sh completes and database is seeded.
+#
+# Usage:
+#   chmod +x test-api.sh
+#   ./test-api.sh
+# =============================================================================
+
+set -euo pipefail
+
+# Load environment
+if [ -f env.sh ]; then
+  source env.sh
+else
+  echo "ERROR: env.sh not found. Run setup.sh first."
+  exit 1
+fi
+
+API_URL="${API_ENDPOINT}/lookup"
+
+echo "============================================"
+echo "DSQL Employee Lookup - API Tests"
+echo "============================================"
+echo "API URL: $API_URL"
+echo ""
+
+# Test 1: List all employees (empty body)
+echo ">>> Test 1: List all employees"
+echo "    POST $API_URL (empty body)"
+curl -s -X POST $API_URL \
+  -H 'Content-Type: application/json' \
+  -d '{}' | jq .
+echo ""
+
+# Test 2: Search by name
+echo ">>> Test 2: Search for 'John'"
+curl -s -X POST $API_URL \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "John"}' | jq .
+echo ""
+
+# Test 3: Search for partial name
+echo ">>> Test 3: Search for 'doe' (case-insensitive)"
+curl -s -X POST $API_URL \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "doe"}' | jq .
+echo ""
+
+# Test 4: Search with no results
+echo ">>> Test 4: Search for 'zzz' (no results expected)"
+curl -s -X POST $API_URL \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "zzz"}' | jq .
+echo ""
+
+# Test 5: Invalid JSON (should return 400)
+echo ">>> Test 5: Invalid JSON body (expect 400)"
+curl -s -X POST $API_URL \
+  -H 'Content-Type: application/json' \
+  -d 'not valid json' | jq .
+echo ""
+
+echo "============================================"
+echo "Tests complete!"
+echo "============================================"


### PR DESCRIPTION
## What does this PR add?

A complete serverless Employee Directory API sample demonstrating Rust on AWS Lambda with Aurora DSQL, using the Aurora DSQL SQLx Connector for IAM authentication and connection pooling.

**Location:** `rust/lambda-employee-lookup/`

## Features demonstrated

- Connecting to Aurora DSQL using `aurora-dsql-sqlx-connector` (v0.2) with automatic IAM token generation and refresh
- Connection pooling with `OnceLock` for reuse across warm Lambda invocations
- Building an HTTP API handler with the official `lambda_http` crate
- Parameterized SQL queries with LIKE-based name search
- Database role setup with least-privilege access (`dsql:DbConnect`)

## Deployment options included

| Approach | Tools provided |
|----------|---------------|
| Container image (recommended) | AWS CLI script, CloudFormation, Terraform |
| Zip package | AWS CLI script, CloudFormation, Terraform |
| macOS Apple Silicon | Finch and Docker scripts (container build) |
## Testing

- Built and deployed successfully on ARM64 Lambda (container image, ~7MB binary)
- API tested end-to-end with Aurora DSQL cluster in us-east-1
- Security scans passed: `git secrets --scan`, `trufflehog`, `cargo audit`
- License compliance verified: all dependencies MIT/Apache-2.0/BSD compatible

## Related

- Companion blog post: "Building a Serverless Employee Directory with Rust on AWS Lambda and Amazon Aurora DSQL"
- Uses connector announced in: https://aws.amazon.com/about-aws/whats-new/2026/03/aurora-dsql-rust-npgsql-connectors/

## Checklist

- [x] Follows existing repo README format (`rust/cluster_management` pattern)
- [x] MIT-0 license (inherited from repo root)
- [x] No hardcoded credentials, account IDs, or real endpoints
- [x] `Cargo.lock` included
- [x] `.gitignore` excludes `target/` and `env.sh`
- [x] Sample data uses `@example.com` (IANA-reserved domain)