### PR TITLE
Fix Rails primary key introspection for DSQL

### DIFF
--- a/ruby/rails/README.md
+++ b/ruby/rails/README.md
@@ -73,6 +73,23 @@ require "active_record/connection_adapters/postgresql/schema_statements"
 module ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
   # Override client_min_messages for DSQL compatibility
   def client_min_messages=(level); end
+
+  # Temporary workaround until the Rails pg_constraint fix is released
+  def primary_keys(table_name)
+    query_values(<<~SQL, "SCHEMA")
+      SELECT a.attname
+        FROM (
+               SELECT conrelid, conkey, generate_subscripts(conkey, 1) idx
+                 FROM pg_constraint
+                WHERE conrelid = #{quote(quote_table_name(table_name))}::regclass
+                  AND contype = 'p'
+             ) c
+        JOIN pg_attribute a
+          ON a.attrelid = c.conrelid
+         AND a.attnum = c.conkey[c.idx]
+       ORDER BY c.idx
+    SQL
+  end
 end
 
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter

--- a/ruby/rails/carrental/.gitignore
+++ b/ruby/rails/carrental/.gitignore
@@ -1,0 +1,2 @@
+/tmp/*
+!/tmp/.keep

--- a/ruby/rails/carrental/Gemfile
+++ b/ruby/rails/carrental/Gemfile
@@ -45,7 +45,6 @@ gem "aurora-dsql-ruby-pg", "~> 1.0", require: "aurora_dsql_pg"
 gem "sqlite3", "~> 2.0"
 
 group :development, :test do
-
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri windows], require: "debug/prelude"
 
@@ -56,8 +55,11 @@ group :development, :test do
   gem "rubocop-rails-omakase", require: false
 end
 
+group :test do
+  gem "minitest", "< 6"
+end
+
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 end
-

--- a/ruby/rails/carrental/config/initializers/dsql_adapter.rb
+++ b/ruby/rails/carrental/config/initializers/dsql_adapter.rb
@@ -58,6 +58,22 @@ require "active_record/connection_adapters/postgresql/schema_statements"
 
 module ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
   def client_min_messages=(level); end
+
+  def primary_keys(table_name)
+    query_values(<<~SQL, "SCHEMA")
+      SELECT a.attname
+        FROM (
+               SELECT conrelid, conkey, generate_subscripts(conkey, 1) idx
+                 FROM pg_constraint
+                WHERE conrelid = #{quote(quote_table_name(table_name))}::regclass
+                  AND contype = 'p'
+             ) c
+        JOIN pg_attribute a
+          ON a.attrelid = c.conrelid
+         AND a.attnum = c.conkey[c.idx]
+       ORDER BY c.idx
+    SQL
+  end
 end
 
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter

--- a/ruby/rails/carrental/test/models/vehicle_test.rb
+++ b/ruby/rails/carrental/test/models/vehicle_test.rb
@@ -21,6 +21,16 @@ class VehicleTest < ActiveSupport::TestCase
     vehicle.destroy!
   end
 
+  test "upsert updates non-primary-key columns" do
+    vehicle = Vehicle.create!(build_vehicle)
+
+    Vehicle.upsert_all([vehicle.attributes.merge("mileage" => 42)])
+
+    assert_equal 42, vehicle.reload.mileage
+  ensure
+    vehicle&.destroy!
+  end
+
   test "requires make and model" do
     vehicle = Vehicle.new(build_vehicle(make: nil, model: nil))
     assert_not vehicle.valid?

--- a/ruby/rails/petclinic/Gemfile
+++ b/ruby/rails/petclinic/Gemfile
@@ -51,6 +51,8 @@ group :development do
 end
 
 group :test do
+  gem "minitest", "< 6"
+
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"

--- a/ruby/rails/petclinic/config/initializers/adapter.rb
+++ b/ruby/rails/petclinic/config/initializers/adapter.rb
@@ -32,6 +32,22 @@ require "active_record/connection_adapters/postgresql/schema_statements"
 module ActiveRecord::ConnectionAdapters::PostgreSQL::SchemaStatements
   # DSQL does not support setting min_messages in the connection parameters
   def client_min_messages=(level); end
+
+  def primary_keys(table_name)
+    query_values(<<~SQL, "SCHEMA")
+      SELECT a.attname
+        FROM (
+               SELECT conrelid, conkey, generate_subscripts(conkey, 1) idx
+                 FROM pg_constraint
+                WHERE conrelid = #{quote(quote_table_name(table_name))}::regclass
+                  AND contype = 'p'
+             ) c
+        JOIN pg_attribute a
+          ON a.attrelid = c.conrelid
+         AND a.attnum = c.conkey[c.idx]
+       ORDER BY c.idx
+    SQL
+  end
 end
 
 class ActiveRecord::ConnectionAdapters::PostgreSQLAdapter

--- a/ruby/rails/petclinic/db/schema.rb
+++ b/ruby/rails/petclinic/db/schema.rb
@@ -16,15 +16,13 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_085734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "owner", primary_key: ["id", "name", "city", "telephone"], force: :cascade do |t|
-    t.uuid "id", default: -> { "gen_random_uuid()" }, null: false
+  create_table "owner", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", limit: 30, null: false
     t.string "city", limit: 80, null: false
     t.string "telephone", limit: 20
   end
 
-  create_table "owners", primary_key: ["id", "name", "city", "telephone", "created_at", "updated_at"], force: :cascade do |t|
-    t.uuid "id", default: -> { "gen_random_uuid()" }, null: false
+  create_table "owners", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", limit: 30
     t.string "city", limit: 80
     t.string "telephone", limit: 20
@@ -32,8 +30,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_085734) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "pets", primary_key: ["id", "name", "birth_date", "owner_id", "created_at", "updated_at"], force: :cascade do |t|
-    t.uuid "id", default: -> { "gen_random_uuid()" }, null: false
+  create_table "pets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", limit: 30
     t.date "birth_date"
     t.uuid "owner_id"
@@ -41,23 +38,20 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_07_085734) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "specialties", primary_key: ["id", "name", "created_at", "updated_at"], force: :cascade do |t|
-    t.uuid "id", default: -> { "gen_random_uuid()" }, null: false
+  create_table "specialties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "vet_specialties", primary_key: ["id", "vet_id", "specialty_id", "created_at", "updated_at"], force: :cascade do |t|
-    t.uuid "id", default: -> { "gen_random_uuid()" }, null: false
+  create_table "vet_specialties", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "vet_id"
     t.uuid "specialty_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "vets", primary_key: ["id", "name", "owner_id", "created_at", "updated_at"], force: :cascade do |t|
-    t.uuid "id", default: -> { "gen_random_uuid()" }, null: false
+  create_table "vets", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", limit: 30
     t.uuid "owner_id"
     t.datetime "created_at", null: false

--- a/ruby/rails/petclinic/test/models/owner_test.rb
+++ b/ruby/rails/petclinic/test/models/owner_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class OwnerTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "upsert updates non-primary-key columns" do
+    owner = owners(:one)
+
+    Owner.upsert_all([owner.attributes.merge("name" => "Updated Name")])
+
+    assert_equal "Updated Name", owner.reload.name
+  end
 end


### PR DESCRIPTION
## Summary

* temporarily override Rails 7.2 primary-key introspection to read `pg_constraint.conkey`
* add bulk-upsert regression coverage to both Rails samples
* correct Petclinic schema primary-key declarations generated by the old query
* pin Minitest below 6 for Rails 7.2 test compatibility
* document the workaround in the Rails sample README

## Testing

* Petclinic: 1 run, 1 assertion, 0 failures
* Car Rental: 13 runs, 33 assertions, 0 failures
* DSQL SQL lint: 0 errors, 0 warnings

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.