### PR TITLE
Fix stale dependabot path and ignore node_modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -90,7 +90,7 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 5
   - package-ecosystem: "npm"
-    directory: "/typescript/prisma"
+    directory: "/typescript/prisma-multi-region"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,9 @@ __pycache__/
 # TypeScript build outputs
 dist/
 
+# Node dependencies
+node_modules/
+
 # Nested git directories in sample projects
 sample-amazon-aurora-dsql-agent/.git/
 


### PR DESCRIPTION
## Summary

* fix the dependabot npm entry: `/typescript/prisma` -> `/typescript/prisma-multi-region`, so that example gets dependency updates again
* ignore `node_modules/` at the root — only some examples declare it in their own `.gitignore`, so tooling run elsewhere leaves untracked directories behind

## Testing

* the corrected path has a tracked `package.json` and `package-lock.json`, so npm updates resolve there
* audited the other 21 dependabot entries; all point at real directories
* no tracked files live under any `node_modules/` path, so the new ignore rule orphans nothing

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
