### PR TITLE
docs: point Flyway users to upstream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The subdirectories contain code examples for connecting and using Aurora DSQL in
 | Typescript  |             [TypeORM](typescript/type-orm)              |
 |    Deno     |        [postgres-js](deno/postgres-js/)              |
 
+For new Flyway schema migrations, prefer a compatible released version of the official
+[`org.flywaydb:flyway-database-dsql`](https://github.com/flyway/flyway-community-db-support/tree/main/flyway-database-dsql)
+community module. Existing users of the AWS adapter can follow its
+[migration guidance](https://github.com/awslabs/aurora-dsql-tools/tree/main/flyway).
 
 |  Language   |                 Cluster Management                  |
 |:-----------:|:---------------------------------------------------:|


### PR DESCRIPTION
## Summary

Point new Flyway users to the official Aurora DSQL community module and direct existing AWS adapter users to the compatibility-preserving migration guidance.

Related: https://github.com/awslabs/aurora-dsql-tools/pull/150

## Testing

- `git diff HEAD^ HEAD --check`

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.

Thank you for your contribution!