### PR TITLE
Use default Rails prepared statements

### DIFF
--- a/ruby/rails/README.md
+++ b/ruby/rails/README.md
@@ -113,8 +113,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV.fetch("CLUSTER_USER") { "admin" } %>
   host: <%= ENV['CLUSTER_ENDPOINT'] %>
-  # Disable prepared statements and advisory locks for Aurora DSQL
-  prepared_statements: false
+  # Disable advisory locks for Aurora DSQL
   advisory_locks: false
   sslnegotiation: direct
   sslmode: verify-full

--- a/ruby/rails/carrental/config/database.yml
+++ b/ruby/rails/carrental/config/database.yml
@@ -27,7 +27,6 @@ test:
   username: <%= ENV.fetch("CLUSTER_USER", "admin") %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
-  prepared_statements: false
   advisory_locks: false
   sslmode: verify-full
   sslnegotiation: direct
@@ -41,11 +40,10 @@ test:
 # Aurora DSQL requires:
 #   - IAM-based authentication (tokens generated per connection)
 #   - SSL with verify-full mode and direct negotiation
-#   - No prepared statements (not supported by DSQL)
 #   - No advisory locks (not supported by DSQL)
 #
 # The DSQL adapter initializer (config/initializers/dsql_adapter.rb)
-# handles IAM token injection and disables unsupported features.
+# handles IAM token injection and Active Record configuration.
 # ---------------------------------------------------------------------------
 production:
   adapter: postgresql
@@ -56,7 +54,6 @@ production:
   username: <%= ENV.fetch("DSQL_USER", "admin") %>
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
-  prepared_statements: false
   advisory_locks: false
   sslmode: verify-full
   sslnegotiation: direct

--- a/ruby/rails/carrental/test/models/vehicle_test.rb
+++ b/ruby/rails/carrental/test/models/vehicle_test.rb
@@ -15,6 +15,10 @@ class VehicleTest < ActiveSupport::TestCase
     }.merge(overrides)
   end
 
+  test "uses prepared statements" do
+    assert ActiveRecord::Base.connection.prepared_statements
+  end
+
   test "creates a valid vehicle" do
     vehicle = Vehicle.create!(build_vehicle)
     assert vehicle.persisted?

--- a/ruby/rails/petclinic/config/database.yml
+++ b/ruby/rails/petclinic/config/database.yml
@@ -21,8 +21,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV.fetch("CLUSTER_USER") { "admin" } %>
   host: <%= ENV['CLUSTER_ENDPOINT'] %>
-  # Disable prepared statements and advisory locks for Aurora DSQL
-  prepared_statements: false
+  # Disable advisory locks for Aurora DSQL
   advisory_locks: false
   sslnegotiation: direct
   sslmode: verify-full

--- a/ruby/rails/petclinic/test/models/owner_test.rb
+++ b/ruby/rails/petclinic/test/models/owner_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class OwnerTest < ActiveSupport::TestCase
+  test "uses prepared statements" do
+    assert ActiveRecord::Base.connection.prepared_statements
+  end
+
   test "upsert updates non-primary-key columns" do
     owner = Owner.create!(name: "Original Name", city: "Seattle")
 


### PR DESCRIPTION
## Summary

- use Rails' standard prepared statement behavior in both Rails samples
- keep database configuration focused on authentication, TLS, and advisory locks
- cover the connection setting in both Rails integration suites

## Testing

- Petclinic integration suite passed against Aurora DSQL
- Car Rental integration suite passed against Aurora DSQL

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.