### PR TITLE
fix(recipe-sharing-api): use reserved amzn-s3-demo- bucket prefix

### DIFF
--- a/go/recipe-sharing-api/README.md
+++ b/go/recipe-sharing-api/README.md
@@ -247,7 +247,7 @@ aws logs tail /aws/apigateway/recipe-share-stack-access-logs --region <region> -
 aws cloudformation delete-stack --stack-name recipe-share-stack --region <region>
 
 # Delete the S3 deployment bucket
-aws s3 rb s3://recipe-share-stack-deploy-<account-id>-<region> --force --region <region>
+aws s3 rb s3://amzn-s3-demo-recipe-share-stack-deploy-<account-id>-<region> --force --region <region>
 
 # Delete the Amazon Aurora DSQL cluster
 aws dsql delete-cluster --identifier <cluster-id> --region <region>

--- a/go/recipe-sharing-api/deploy.sh
+++ b/go/recipe-sharing-api/deploy.sh
@@ -99,7 +99,7 @@ fi
 DSQL_ENDPOINT="${DSQL_CLUSTER_ID}.dsql.${REGION}.on.aws"
 
 # Derived names
-S3_BUCKET="${STACK_NAME}-deploy-${ACCOUNT}-${REGION}"
+S3_BUCKET="amzn-s3-demo-${STACK_NAME}-deploy-${ACCOUNT}-${REGION}"
 S3_KEY="lambda/bootstrap.zip"
 BINARY_NAME="bootstrap"
 ZIP_NAME="bootstrap.zip"


### PR DESCRIPTION
Rename the S3 deployment bucket to use the reserved 'amzn-s3-demo-' prefix so it follows the AWS documentation naming convention for example buckets.

The bucket name is derived from STACK_NAME in deploy.sh, so prepending the prefix to the derived name preserves the --stack-name override and propagates the new name to bucket creation, package upload, the LambdaS3Bucket CloudFormation parameter, and the tear-down hint. The matching cleanup command in README.md is updated to the same name.

By submitting this pull request, I confirm that my contribution is made under 
the terms of the MIT-0 license.

Thank you for your contribution!